### PR TITLE
Implement v0.1 [Ignore] attribute support

### DIFF
--- a/src/TypeForge.Generator/ForgeCodeEmitter.cs
+++ b/src/TypeForge.Generator/ForgeCodeEmitter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -12,10 +13,12 @@ namespace TypeForge.Generator;
 internal sealed class ForgeCodeEmitter
 {
     private readonly Compilation _compilation;
+    private readonly INamedTypeSymbol? _ignoreAttributeSymbol;
 
     public ForgeCodeEmitter(Compilation compilation)
     {
         _compilation = compilation;
+        _ignoreAttributeSymbol = compilation.GetTypeByMetadataName("TypeForge.IgnoreAttribute");
     }
 
     public string GenerateForger(ForgerInfo forger, SourceProductionContext context)
@@ -117,6 +120,9 @@ internal sealed class ForgeCodeEmitter
         var sb = new StringBuilder();
         var sourceParam = method.Parameters[0].Name;
 
+        // Get ignored properties from [Ignore] attributes
+        var ignoredProperties = GetIgnoredProperties(method);
+
         // Method signature
         var accessibility = GetAccessibilityKeyword(method.DeclaredAccessibility);
         sb.AppendLine($"        {accessibility} partial {destinationType.ToDisplayString()} {method.Name}({sourceType.ToDisplayString()} {sourceParam})");
@@ -136,6 +142,10 @@ internal sealed class ForgeCodeEmitter
 
         foreach (var destProp in destProperties)
         {
+            // Skip ignored properties
+            if (ignoredProperties.Contains(destProp.Name))
+                continue;
+
             // Try to find matching source property by name
             var sourceProp = sourceProperties.FirstOrDefault(sp =>
                 string.Equals(sp.Name, destProp.Name, StringComparison.Ordinal));
@@ -150,6 +160,38 @@ internal sealed class ForgeCodeEmitter
         sb.AppendLine("        }");
 
         return sb.ToString();
+    }
+
+    private HashSet<string> GetIgnoredProperties(IMethodSymbol method)
+    {
+        var ignored = new HashSet<string>(StringComparer.Ordinal);
+
+        if (_ignoreAttributeSymbol == null)
+            return ignored;
+
+        foreach (var attr in method.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attr.AttributeClass, _ignoreAttributeSymbol))
+                continue;
+
+            // The [Ignore] attribute takes params string[] propertyNames
+            if (attr.ConstructorArguments.Length > 0)
+            {
+                var arg = attr.ConstructorArguments[0];
+                if (arg.Kind == TypedConstantKind.Array)
+                {
+                    foreach (var item in arg.Values)
+                    {
+                        if (item.Value is string propName)
+                        {
+                            ignored.Add(propName);
+                        }
+                    }
+                }
+            }
+        }
+
+        return ignored;
     }
 
     private string GenerateForgeIntoMethod(
@@ -168,6 +210,9 @@ internal sealed class ForgeCodeEmitter
             p.GetAttributes().Any(a =>
                 a.AttributeClass?.Name == "UseExistingValueAttribute")).Name;
 
+        // Get ignored properties from [Ignore] attributes
+        var ignoredProperties = GetIgnoredProperties(method);
+
         // Method signature
         var accessibility = GetAccessibilityKeyword(method.DeclaredAccessibility);
         sb.AppendLine($"        {accessibility} partial void {method.Name}({sourceType.ToDisplayString()} {sourceParam}, {destinationType.ToDisplayString()} {destParam})");
@@ -184,6 +229,10 @@ internal sealed class ForgeCodeEmitter
 
         foreach (var destProp in destProperties)
         {
+            // Skip ignored properties
+            if (ignoredProperties.Contains(destProp.Name))
+                continue;
+
             var sourceProp = sourceProperties.FirstOrDefault(sp =>
                 string.Equals(sp.Name, destProp.Name, StringComparison.Ordinal));
 

--- a/tests/TypeForge.Tests/BasicMappingTests.cs
+++ b/tests/TypeForge.Tests/BasicMappingTests.cs
@@ -1,12 +1,318 @@
+using FluentAssertions;
+using TypeForge;
+using Xunit;
+
 namespace TypeForge.Tests;
+
+#region Test Models
+
+public class OrderEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Total { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public string InternalCode { get; set; } = string.Empty;
+}
+
+public class OrderDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Total { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public string InternalCode { get; set; } = string.Empty;
+}
+
+public class UserEntity
+{
+    public int Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+    public string SecurityStamp { get; set; } = string.Empty;
+}
+
+public class UserDto
+{
+    public int Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+    public string SecurityStamp { get; set; } = string.Empty;
+}
+
+public class ProductEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public int Quantity { get; set; }
+}
+
+public class ProductDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public int Quantity { get; set; }
+    public string Description { get; set; } = string.Empty; // Unmapped
+}
+
+#endregion
+
+#region Forgers
+
+[TypeForge]
+public partial class AppForger
+{
+    /// <summary>
+    /// Simple property mapping - all properties matched by name.
+    /// </summary>
+    public partial OrderDto Forge(OrderEntity source);
+
+    /// <summary>
+    /// Mapping with ignored properties - sensitive data excluded.
+    /// </summary>
+    [Ignore(nameof(UserDto.PasswordHash), nameof(UserDto.SecurityStamp))]
+    public partial UserDto Forge(UserEntity source);
+
+    /// <summary>
+    /// Mapping with single ignored property.
+    /// </summary>
+    [Ignore(nameof(ProductDto.Description))]
+    public partial ProductDto Forge(ProductEntity source);
+
+    /// <summary>
+    /// ForgeInto pattern - updates existing destination instance.
+    /// </summary>
+    public partial void ForgeInto(OrderEntity source, [UseExistingValue] OrderDto destination);
+
+    /// <summary>
+    /// ForgeInto with ignored properties.
+    /// </summary>
+    [Ignore(nameof(UserDto.PasswordHash))]
+    public partial void ForgeInto(UserEntity source, [UseExistingValue] UserDto destination);
+}
+
+#endregion
 
 public class BasicMappingTests
 {
+    private readonly AppForger _forger = new();
+
     [Fact]
-    public void SimplePropertyMapping_ShouldMapMatchingProperties()
+    public void SimplePropertyMapping_ShouldMapAllMatchingProperties()
     {
-        // This test will work once the generator is fully implemented
-        // For now, it serves as a placeholder to verify the test project builds
-        Assert.True(true);
+        // Arrange
+        var entity = new OrderEntity
+        {
+            Id = 123,
+            Name = "Test Order",
+            Total = 99.99m,
+            CreatedAt = new DateTime(2024, 1, 15),
+            InternalCode = "INTERNAL"
+        };
+
+        // Act
+        var dto = _forger.Forge(entity);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Id.Should().Be(123);
+        dto.Name.Should().Be("Test Order");
+        dto.Total.Should().Be(99.99m);
+        dto.CreatedAt.Should().Be(new DateTime(2024, 1, 15));
+        dto.InternalCode.Should().Be("INTERNAL");
+    }
+
+    [Fact]
+    public void NullSource_ShouldReturnNull()
+    {
+        // Arrange
+        OrderEntity? entity = null;
+
+        // Act
+        var dto = _forger.Forge(entity!);
+
+        // Assert
+        dto.Should().BeNull();
+    }
+
+    [Fact]
+    public void IgnoreAttribute_ShouldExcludeSpecifiedProperties()
+    {
+        // Arrange
+        var entity = new UserEntity
+        {
+            Id = 1,
+            Username = "john.doe",
+            Email = "john@example.com",
+            PasswordHash = "secret_hash_abc123",
+            SecurityStamp = "stamp_xyz789"
+        };
+
+        // Act
+        var dto = _forger.Forge(entity);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Id.Should().Be(1);
+        dto.Username.Should().Be("john.doe");
+        dto.Email.Should().Be("john@example.com");
+        // Ignored properties should have default values (not mapped)
+        dto.PasswordHash.Should().BeNullOrEmpty();
+        dto.SecurityStamp.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public void IgnoreSingleProperty_ShouldExcludeOnlyThatProperty()
+    {
+        // Arrange
+        var entity = new ProductEntity
+        {
+            Id = 42,
+            Name = "Widget",
+            Price = 19.99m,
+            Quantity = 100
+        };
+
+        // Act
+        var dto = _forger.Forge(entity);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Id.Should().Be(42);
+        dto.Name.Should().Be("Widget");
+        dto.Price.Should().Be(19.99m);
+        dto.Quantity.Should().Be(100);
+        // Description is not in source and is ignored anyway
+        dto.Description.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MultipleForgerMethods_ShouldWorkIndependently()
+    {
+        // Arrange
+        var orderEntity = new OrderEntity { Id = 1, Name = "Order 1", Total = 50m };
+        var userEntity = new UserEntity { Id = 2, Username = "jane", Email = "jane@test.com" };
+
+        // Act
+        var orderDto = _forger.Forge(orderEntity);
+        var userDto = _forger.Forge(userEntity);
+
+        // Assert
+        orderDto.Should().NotBeNull();
+        orderDto.Id.Should().Be(1);
+        orderDto.Name.Should().Be("Order 1");
+
+        userDto.Should().NotBeNull();
+        userDto.Id.Should().Be(2);
+        userDto.Username.Should().Be("jane");
     }
 }
+
+public class ForgeIntoTests
+{
+    private readonly AppForger _forger = new();
+
+    [Fact]
+    public void ForgeInto_ShouldUpdateExistingInstance()
+    {
+        // Arrange
+        var source = new OrderEntity
+        {
+            Id = 10,
+            Name = "Updated Order",
+            Total = 250.00m,
+            CreatedAt = new DateTime(2024, 6, 1),
+            InternalCode = "NEW_CODE"
+        };
+        var existing = new OrderDto
+        {
+            Id = 999,
+            Name = "Old Name",
+            Total = 0m,
+            CreatedAt = DateTime.MinValue,
+            InternalCode = "OLD_CODE"
+        };
+
+        // Act
+        _forger.ForgeInto(source, existing);
+
+        // Assert
+        existing.Id.Should().Be(10);
+        existing.Name.Should().Be("Updated Order");
+        existing.Total.Should().Be(250.00m);
+        existing.CreatedAt.Should().Be(new DateTime(2024, 6, 1));
+        existing.InternalCode.Should().Be("NEW_CODE");
+    }
+
+    [Fact]
+    public void ForgeInto_NullSource_ShouldNotModifyDestination()
+    {
+        // Arrange
+        OrderEntity? source = null;
+        var existing = new OrderDto
+        {
+            Id = 999,
+            Name = "Original",
+            Total = 100m
+        };
+
+        // Act
+        _forger.ForgeInto(source!, existing);
+
+        // Assert - destination should remain unchanged
+        existing.Id.Should().Be(999);
+        existing.Name.Should().Be("Original");
+        existing.Total.Should().Be(100m);
+    }
+
+    [Fact]
+    public void ForgeInto_NullDestination_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var source = new OrderEntity { Id = 1, Name = "Test" };
+        OrderDto? destination = null;
+
+        // Act & Assert
+        var action = () => _forger.ForgeInto(source, destination!);
+        action.Should().Throw<ArgumentNullException>()
+            .WithParameterName("destination");
+    }
+
+    [Fact]
+    public void ForgeInto_WithIgnore_ShouldNotUpdateIgnoredProperties()
+    {
+        // Arrange
+        var source = new UserEntity
+        {
+            Id = 5,
+            Username = "newuser",
+            Email = "new@example.com",
+            PasswordHash = "new_hash",
+            SecurityStamp = "new_stamp"
+        };
+        var existing = new UserDto
+        {
+            Id = 999,
+            Username = "olduser",
+            Email = "old@example.com",
+            PasswordHash = "old_hash",
+            SecurityStamp = "old_stamp"
+        };
+
+        // Act
+        _forger.ForgeInto(source, existing);
+
+        // Assert
+        existing.Id.Should().Be(5);
+        existing.Username.Should().Be("newuser");
+        existing.Email.Should().Be("new@example.com");
+        // PasswordHash is ignored (SecurityStamp is not ignored in ForgeInto)
+        existing.PasswordHash.Should().Be("old_hash");
+        existing.SecurityStamp.Should().Be("new_stamp");
+    }
+}
+

--- a/tests/TypeForge.Tests/SourceGeneratorTests.cs
+++ b/tests/TypeForge.Tests/SourceGeneratorTests.cs
@@ -1,0 +1,270 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TypeForge.Generator;
+using Xunit;
+using System.Diagnostics;
+
+namespace TypeForge.Tests;
+
+/// <summary>
+/// Tests that verify the source generator produces correct code.
+/// </summary>
+public class SourceGeneratorTests
+{
+    [Fact]
+    public void Generator_SimplePropertyMapping_GeneratesCorrectCode()
+    {
+        // Arrange
+        var source = """
+            using TypeForge;
+
+            namespace TestNamespace
+            {
+                public class SourceEntity
+                {
+                    public int Id { get; set; }
+                    public string Name { get; set; }
+                }
+
+                public class DestDto
+                {
+                    public int Id { get; set; }
+                    public string Name { get; set; }
+                }
+
+                [TypeForge]
+                public partial class TestForger
+                {
+                    public partial DestDto Forge(SourceEntity source);
+                }
+            }
+            """;
+
+        // Act
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        // Assert
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Single(generatedTrees);
+
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Debug.WriteLine($"Generated code:\n{generatedCode}");
+
+        Assert.Contains("partial", generatedCode);
+        Assert.Contains("DestDto", generatedCode);
+        Assert.Contains("Forge", generatedCode);
+        Assert.Contains("Id = source.Id,", generatedCode);
+        Assert.Contains("Name = source.Name,", generatedCode);
+        Assert.Contains("if (source == null) return null!", generatedCode);
+    }
+
+    [Fact]
+    public void Generator_IgnoreAttribute_ExcludesProperties()
+    {
+        // Arrange
+        var source = """
+            using TypeForge;
+
+            namespace TestNamespace
+            {
+                public class SourceEntity
+                {
+                    public int Id { get; set; }
+                    public string Name { get; set; }
+                    public string Secret { get; set; }
+                }
+
+                public class DestDto
+                {
+                    public int Id { get; set; }
+                    public string Name { get; set; }
+                    public string Secret { get; set; }
+                }
+
+                [TypeForge]
+                public partial class TestForger
+                {
+                    [Ignore(nameof(DestDto.Secret))]
+                    public partial DestDto Forge(SourceEntity source);
+                }
+            }
+            """;
+
+        // Act
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        // Assert
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Single(generatedTrees);
+
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Assert.Contains("Id = source.Id,", generatedCode);
+        Assert.Contains("Name = source.Name,", generatedCode);
+        Assert.DoesNotContain("Secret = source.Secret", generatedCode);
+    }
+
+    [Fact]
+    public void Generator_IgnoreMultipleProperties_ExcludesAllSpecified()
+    {
+        // Arrange
+        var source = """
+            using TypeForge;
+
+            namespace TestNamespace
+            {
+                public class SourceEntity
+                {
+                    public int Id { get; set; }
+                    public string PasswordHash { get; set; }
+                    public string SecurityStamp { get; set; }
+                }
+
+                public class DestDto
+                {
+                    public int Id { get; set; }
+                    public string PasswordHash { get; set; }
+                    public string SecurityStamp { get; set; }
+                }
+
+                [TypeForge]
+                public partial class TestForger
+                {
+                    [Ignore(nameof(DestDto.PasswordHash), nameof(DestDto.SecurityStamp))]
+                    public partial DestDto Forge(SourceEntity source);
+                }
+            }
+            """;
+
+        // Act
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        // Assert
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Assert.Contains("Id = source.Id,", generatedCode);
+        Assert.DoesNotContain("PasswordHash = source.PasswordHash", generatedCode);
+        Assert.DoesNotContain("SecurityStamp = source.SecurityStamp", generatedCode);
+    }
+
+    [Fact]
+    public void Generator_NonPartialClass_ReportsError()
+    {
+        // Arrange
+        var source = """
+            using TypeForge;
+
+            namespace TestNamespace
+            {
+                [TypeForge]
+                public class NonPartialForger
+                {
+                    public partial DestDto Forge(SourceEntity source);
+                }
+
+                public class SourceEntity { public int Id { get; set; } }
+                public class DestDto { public int Id { get; set; } }
+            }
+            """;
+
+        // Act
+        var (diagnostics, _) = RunGenerator(source);
+
+        // Assert
+        var error = diagnostics.FirstOrDefault(d => d.Id == "TF0001");
+        Assert.NotNull(error);
+        Assert.Equal(DiagnosticSeverity.Error, error.Severity);
+    }
+
+    [Fact]
+    public void Generator_ForgeInto_GeneratesCorrectCode()
+    {
+        // Arrange
+        var source = """
+            using TypeForge;
+
+            namespace TestNamespace
+            {
+                public class SourceEntity
+                {
+                    public int Id { get; set; }
+                    public string Name { get; set; }
+                }
+
+                public class DestDto
+                {
+                    public int Id { get; set; }
+                    public string Name { get; set; }
+                }
+
+                [TypeForge]
+                public partial class TestForger
+                {
+                    public partial void ForgeInto(SourceEntity source, [UseExistingValue] DestDto destination);
+                }
+            }
+            """;
+
+        // Act
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        // Assert
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Single(generatedTrees);
+
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Debug.WriteLine($"ForgeInto generated code:\n{generatedCode}");
+
+        Assert.Contains("partial void ForgeInto", generatedCode);
+        Assert.Contains("destination.Id = source.Id;", generatedCode);
+        Assert.Contains("destination.Name = source.Name;", generatedCode);
+        Assert.Contains("if (destination == null) throw new global::System.ArgumentNullException", generatedCode);
+        Assert.Contains("if (source == null) return;", generatedCode);
+    }
+
+    private static (IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<SyntaxTree> GeneratedTrees) RunGenerator(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        // Get references to the TypeForge.Abstractions assembly
+        var abstractionsAssembly = typeof(TypeForgeAttribute).Assembly;
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+            MetadataReference.CreateFromFile(abstractionsAssembly.Location)
+        };
+
+        // Add reference to System.Runtime
+        var runtimeAssembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "System.Runtime");
+        if (runtimeAssembly != null)
+        {
+            references.Add(MetadataReference.CreateFromFile(runtimeAssembly.Location));
+        }
+
+        // Add reference to netstandard
+        var netstandardAssembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "netstandard");
+        if (netstandardAssembly != null)
+        {
+            references.Add(MetadataReference.CreateFromFile(netstandardAssembly.Location));
+        }
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new TypeForgeGenerator();
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+        var runResult = driver.GetRunResult();
+        var generatedTrees = runResult.GeneratedTrees.ToList();
+
+        return (diagnostics.ToList(), generatedTrees);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement [Ignore] attribute parsing in source generator
- Add filtering of ignored properties in Forge() and ForgeInto() code generation
- Complete v0.1 feature set per spec.md (core generator, property matching, [Ignore])

## Test plan
- [x] All 14 unit tests pass
- [x] Basic property mapping works correctly
- [x] [Ignore] excludes specified destination properties
- [x] ForgeInto updates existing instances in-place
- [x] Null handling works as expected
- [x] Source generator verification tests validate generated code