### PR TITLE
Bump version prefix to 0.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
     <Copyright>Copyright (c) TypeForge Contributors</Copyright>
 
     <!-- Versioning -->
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
 
     <!-- SourceLink & deterministic builds -->


### PR DESCRIPTION
## Summary
- Update `VersionPrefix` in `Directory.Build.props` from `0.2.0` to `0.3.0` to align with the v0.3 collections and `[ForgeWith]` feature release.

## To release
After merging, create a GitHub release with tag `v0.3.0-alpha` to publish to nuget.org.