### PR TITLE
Bump version prefix to 0.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
     <Copyright>Copyright (c) ForgeMap Contributors</Copyright>
 
     <!-- Versioning -->
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
 
     <!-- SourceLink & deterministic builds -->


### PR DESCRIPTION
## Summary
- Bumps `VersionPrefix` from `0.3.0` to `0.4.0` in `Directory.Build.props`
- v0.4 features (enums, constructor mapping, automatic flattening) were already implemented in #10 but the version was never updated

## Test plan
- [x] `dotnet build` succeeds with 0 warnings
- [x] All 63 tests pass