### PR TITLE
Implement v1.1 Feature 2: [IncludeBaseForge] configuration inheritance

### DIFF
--- a/src/ForgeMap.Abstractions/IncludeBaseForgeAttribute.cs
+++ b/src/ForgeMap.Abstractions/IncludeBaseForgeAttribute.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace ForgeMap;
+
+/// <summary>
+/// Inherits attribute-based configuration (<see cref="IgnoreAttribute"/>, <see cref="ForgePropertyAttribute"/>,
+/// <see cref="ForgeFromAttribute"/>, <see cref="ForgeWithAttribute"/>) from a base forge method that maps
+/// <see cref="BaseSourceType"/> → <see cref="BaseDestinationType"/>.
+/// The base forge method must exist in the same forger class.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+public sealed class IncludeBaseForgeAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new <see cref="IncludeBaseForgeAttribute"/>.
+    /// </summary>
+    /// <param name="baseSourceType">The source type of the base forge method to inherit configuration from.</param>
+    /// <param name="baseDestinationType">The destination type (return type) of the base forge method to inherit configuration from.</param>
+    public IncludeBaseForgeAttribute(Type baseSourceType, Type baseDestinationType)
+    {
+        BaseSourceType = baseSourceType ?? throw new ArgumentNullException(nameof(baseSourceType));
+        BaseDestinationType = baseDestinationType ?? throw new ArgumentNullException(nameof(baseDestinationType));
+    }
+
+    /// <summary>
+    /// Gets the source type of the base forge method.
+    /// </summary>
+    public Type BaseSourceType { get; }
+
+    /// <summary>
+    /// Gets the destination type (return type) of the base forge method.
+    /// </summary>
+    public Type BaseDestinationType { get; }
+}

--- a/src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,10 @@
 ; Unshipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+FM0019 | ForgeMap | Error | [IncludeBaseForge] references missing base forge method
+FM0020 | ForgeMap | Error | [IncludeBaseForge] type inheritance mismatch
+FM0021 | ForgeMap | Info | Inherited attribute overridden by explicit attribute

--- a/src/ForgeMap.Generator/DiagnosticDescriptors.cs
+++ b/src/ForgeMap.Generator/DiagnosticDescriptors.cs
@@ -152,4 +152,28 @@ internal static class DiagnosticDescriptors
         category: Category,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor IncludeBaseForgeMethodNotFound = new(
+        id: "FM0019",
+        title: "[IncludeBaseForge] references missing base forge method",
+        messageFormat: "No forge method mapping '{0}' → '{1}' was found in this forger",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor IncludeBaseForgeTypeMismatch = new(
+        id: "FM0020",
+        title: "[IncludeBaseForge] type inheritance mismatch",
+        messageFormat: "Type '{0}' does not derive from '{1}' specified in [IncludeBaseForge]",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor IncludeBaseForgeAttributeOverridden = new(
+        id: "FM0021",
+        title: "Inherited attribute overridden by explicit attribute",
+        messageFormat: "Inherited configuration for property '{0}' is overridden by an explicit attribute on this method",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
 }

--- a/src/ForgeMap.Generator/ForgeCodeEmitter.cs
+++ b/src/ForgeMap.Generator/ForgeCodeEmitter.cs
@@ -40,6 +40,7 @@ internal sealed class ForgeCodeEmitter
     private readonly INamedTypeSymbol? _reverseForgeAttributeSymbol;
     private readonly INamedTypeSymbol? _beforeForgeAttributeSymbol;
     private readonly INamedTypeSymbol? _afterForgeAttributeSymbol;
+    private readonly INamedTypeSymbol? _includeBaseForgeAttributeSymbol;
     private readonly ForgerConfig _assemblyDefaults;
     private ForgerConfig _config = null!;
 
@@ -52,6 +53,7 @@ internal sealed class ForgeCodeEmitter
         _reverseForgeAttributeSymbol = compilation.GetTypeByMetadataName("ForgeMap.ReverseForgeAttribute");
         _beforeForgeAttributeSymbol = compilation.GetTypeByMetadataName("ForgeMap.BeforeForgeAttribute");
         _afterForgeAttributeSymbol = compilation.GetTypeByMetadataName("ForgeMap.AfterForgeAttribute");
+        _includeBaseForgeAttributeSymbol = compilation.GetTypeByMetadataName("ForgeMap.IncludeBaseForgeAttribute");
         _assemblyDefaults = assemblyDefaults;
     }
 
@@ -756,6 +758,10 @@ internal sealed class ForgeCodeEmitter
 
         // Get [ForgeWith] mappings for nested object forging
         var forgeWithMappings = GetForgeWithMappings(method);
+
+        // Merge inherited configuration from [IncludeBaseForge] attributes
+        MergeBaseForgeConfig(method, forger, context, sourceType, destinationType,
+            ignoredProperties, propertyMappings, resolverMappings, forgeWithMappings);
 
         // Get [BeforeForge] and [AfterForge] hooks
         var beforeForgeHooks = GetBeforeForgeHooks(method);
@@ -1571,6 +1577,211 @@ internal sealed class ForgeCodeEmitter
     }
 
     /// <summary>
+    /// Merges inherited configuration from [IncludeBaseForge] attributes into the current method's
+    /// configuration collections. Base attributes are added first with derived overrides taking precedence.
+    /// Supports chaining through multiple levels of [IncludeBaseForge].
+    /// </summary>
+    private void MergeBaseForgeConfig(
+        IMethodSymbol method,
+        ForgerInfo forger,
+        SourceProductionContext context,
+        INamedTypeSymbol sourceType,
+        INamedTypeSymbol destinationType,
+        HashSet<string> ignoredProperties,
+        Dictionary<string, string> propertyMappings,
+        Dictionary<string, string> resolverMappings,
+        Dictionary<string, string> forgeWithMappings)
+    {
+        if (_includeBaseForgeAttributeSymbol == null)
+            return;
+
+        var includeBaseForgeAttrs = method.GetAttributes()
+            .Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, _includeBaseForgeAttributeSymbol))
+            .ToList();
+
+        if (includeBaseForgeAttrs.Count == 0)
+            return;
+
+        // Snapshot the explicitly declared configs so we can detect overrides
+        var explicitIgnored = new HashSet<string>(ignoredProperties, StringComparer.Ordinal);
+        var explicitPropertyMappings = new Dictionary<string, string>(propertyMappings, StringComparer.Ordinal);
+        var explicitResolverMappings = new Dictionary<string, string>(resolverMappings, StringComparer.Ordinal);
+        var explicitForgeWithMappings = new Dictionary<string, string>(forgeWithMappings, StringComparer.Ordinal);
+
+        foreach (var attr in includeBaseForgeAttrs)
+        {
+            if (attr.ConstructorArguments.Length < 2)
+                continue;
+
+            var baseSourceTypeSymbol = attr.ConstructorArguments[0].Value as INamedTypeSymbol;
+            var baseDestTypeSymbol = attr.ConstructorArguments[1].Value as INamedTypeSymbol;
+
+            if (baseSourceTypeSymbol == null || baseDestTypeSymbol == null)
+                continue;
+
+            // Validate: source type must derive from base source type
+            if (!InheritsFrom(sourceType, baseSourceTypeSymbol))
+            {
+                ReportDiagnosticIfNotSuppressed(context,
+                    DiagnosticDescriptors.IncludeBaseForgeTypeMismatch,
+                    method.Locations.FirstOrDefault(),
+                    sourceType.ToDisplayString(),
+                    baseSourceTypeSymbol.ToDisplayString());
+                continue;
+            }
+
+            // Validate: destination type must derive from base destination type
+            if (!InheritsFrom(destinationType, baseDestTypeSymbol))
+            {
+                ReportDiagnosticIfNotSuppressed(context,
+                    DiagnosticDescriptors.IncludeBaseForgeTypeMismatch,
+                    method.Locations.FirstOrDefault(),
+                    destinationType.ToDisplayString(),
+                    baseDestTypeSymbol.ToDisplayString());
+                continue;
+            }
+
+            // Find the base forge method in this forger
+            var baseMethod = FindBaseForgeMethod(forger, baseSourceTypeSymbol, baseDestTypeSymbol);
+            if (baseMethod == null)
+            {
+                ReportDiagnosticIfNotSuppressed(context,
+                    DiagnosticDescriptors.IncludeBaseForgeMethodNotFound,
+                    method.Locations.FirstOrDefault(),
+                    baseSourceTypeSymbol.ToDisplayString(),
+                    baseDestTypeSymbol.ToDisplayString());
+                continue;
+            }
+
+            // Recursively collect base configs (supports chaining)
+            var baseIgnored = GetIgnoredProperties(baseMethod);
+            var basePropMappings = GetPropertyMappings(baseMethod);
+            var baseResolverMappings = GetResolverMappings(baseMethod);
+            var baseForgeWithMappings = GetForgeWithMappings(baseMethod);
+
+            // Recurse: the base method itself may have [IncludeBaseForge]
+            MergeBaseForgeConfig(baseMethod, forger, context, baseSourceTypeSymbol, baseDestTypeSymbol,
+                baseIgnored, basePropMappings, baseResolverMappings, baseForgeWithMappings);
+
+            // Merge base into current, with explicit attrs taking precedence
+            // Merge [Ignore] — add base ignores unless the property is explicitly configured on derived
+            foreach (var prop in baseIgnored)
+            {
+                if (explicitIgnored.Contains(prop) ||
+                    explicitPropertyMappings.ContainsKey(prop) ||
+                    explicitResolverMappings.ContainsKey(prop) ||
+                    explicitForgeWithMappings.ContainsKey(prop))
+                {
+                    // Explicit attribute overrides inherited ignore
+                    ReportDiagnosticIfNotSuppressed(context,
+                        DiagnosticDescriptors.IncludeBaseForgeAttributeOverridden,
+                        method.Locations.FirstOrDefault(),
+                        prop);
+                    continue;
+                }
+                ignoredProperties.Add(prop);
+            }
+
+            // Merge [ForgeProperty] — add base property mappings unless explicitly set on derived
+            foreach (var kvp in basePropMappings)
+            {
+                if (explicitPropertyMappings.ContainsKey(kvp.Key) ||
+                    explicitIgnored.Contains(kvp.Key) ||
+                    explicitResolverMappings.ContainsKey(kvp.Key) ||
+                    explicitForgeWithMappings.ContainsKey(kvp.Key))
+                {
+                    ReportDiagnosticIfNotSuppressed(context,
+                        DiagnosticDescriptors.IncludeBaseForgeAttributeOverridden,
+                        method.Locations.FirstOrDefault(),
+                        kvp.Key);
+                    continue;
+                }
+                if (!propertyMappings.ContainsKey(kvp.Key))
+                    propertyMappings[kvp.Key] = kvp.Value;
+            }
+
+            // Merge [ForgeFrom] — add base resolvers unless explicitly set on derived
+            foreach (var kvp in baseResolverMappings)
+            {
+                if (explicitResolverMappings.ContainsKey(kvp.Key) ||
+                    explicitIgnored.Contains(kvp.Key) ||
+                    explicitPropertyMappings.ContainsKey(kvp.Key) ||
+                    explicitForgeWithMappings.ContainsKey(kvp.Key))
+                {
+                    ReportDiagnosticIfNotSuppressed(context,
+                        DiagnosticDescriptors.IncludeBaseForgeAttributeOverridden,
+                        method.Locations.FirstOrDefault(),
+                        kvp.Key);
+                    continue;
+                }
+                if (!resolverMappings.ContainsKey(kvp.Key))
+                    resolverMappings[kvp.Key] = kvp.Value;
+            }
+
+            // Merge [ForgeWith] — add base forge-with mappings unless explicitly set on derived
+            foreach (var kvp in baseForgeWithMappings)
+            {
+                if (explicitForgeWithMappings.ContainsKey(kvp.Key) ||
+                    explicitIgnored.Contains(kvp.Key) ||
+                    explicitPropertyMappings.ContainsKey(kvp.Key) ||
+                    explicitResolverMappings.ContainsKey(kvp.Key))
+                {
+                    ReportDiagnosticIfNotSuppressed(context,
+                        DiagnosticDescriptors.IncludeBaseForgeAttributeOverridden,
+                        method.Locations.FirstOrDefault(),
+                        kvp.Key);
+                    continue;
+                }
+                if (!forgeWithMappings.ContainsKey(kvp.Key))
+                    forgeWithMappings[kvp.Key] = kvp.Value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Finds a forge method in the forger that maps baseSourceType → baseDestType.
+    /// </summary>
+    private static IMethodSymbol? FindBaseForgeMethod(
+        ForgerInfo forger,
+        INamedTypeSymbol baseSourceType,
+        INamedTypeSymbol baseDestType)
+    {
+        return forger.Symbol.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(m => m.IsPartialDefinition && m.Parameters.Length >= 1)
+            .FirstOrDefault(m =>
+            {
+                var paramType = m.Parameters[0].Type as INamedTypeSymbol;
+                var returnType = m.ReturnType as INamedTypeSymbol;
+                if (paramType == null || returnType == null)
+                    return false;
+
+                return SymbolEqualityComparer.Default.Equals(paramType, baseSourceType) &&
+                       SymbolEqualityComparer.Default.Equals(returnType, baseDestType);
+            });
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="derived"/> derives from <paramref name="baseType"/>,
+    /// or if they are the same type (identity is allowed for [IncludeBaseForge] since
+    /// the types may be identical when only config inheritance is needed).
+    /// </summary>
+    private static bool InheritsFrom(INamedTypeSymbol derived, INamedTypeSymbol baseType)
+    {
+        if (SymbolEqualityComparer.Default.Equals(derived, baseType))
+            return true;
+
+        var current = derived.BaseType;
+        while (current != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, baseType))
+                return true;
+            current = current.BaseType;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Validates a BeforeForge hook method. Must be void with a single parameter matching the source type.
     /// </summary>
     private bool ValidateBeforeForgeHook(
@@ -1844,6 +2055,10 @@ internal sealed class ForgeCodeEmitter
 
         // Get [ForgeWith] mappings for nested object forging
         var forgeWithMappings = GetForgeWithMappings(method);
+
+        // Merge inherited configuration from [IncludeBaseForge] attributes
+        MergeBaseForgeConfig(method, forger, context, sourceNamedType, destinationType,
+            ignoredProperties, propertyMappings, resolverMappings, forgeWithMappings);
 
         // Get [BeforeForge] and [AfterForge] hooks
         var beforeForgeHooks = GetBeforeForgeHooks(method);
@@ -2243,12 +2458,60 @@ internal sealed class ForgeCodeEmitter
         if (type == null)
             return Enumerable.Empty<IPropertySymbol>();
 
-        return type.GetMembers()
-            .OfType<IPropertySymbol>()
-            .Where(p => p.DeclaredAccessibility == Accessibility.Public &&
-                       !p.IsStatic &&
-                       !p.IsIndexer &&
-                       p.GetMethod != null);
+        // Walk the full BaseType chain to collect all accessible properties,
+        // including those from base types in compiled assemblies (v1.1 Feature 1).
+        // If a derived type shadows a base property (new keyword), the derived declaration wins.
+        var levels = new List<List<IPropertySymbol>>();
+
+        var current = type;
+        while (current != null && current.SpecialType != SpecialType.System_Object)
+        {
+            var levelProps = new List<IPropertySymbol>();
+            foreach (var prop in current.GetMembers().OfType<IPropertySymbol>())
+            {
+                if (prop.DeclaredAccessibility == Accessibility.Public &&
+                    !prop.IsStatic &&
+                    !prop.IsIndexer &&
+                    prop.GetMethod != null)
+                {
+                    levelProps.Add(prop);
+                }
+            }
+            levels.Add(levelProps);
+            current = current.BaseType;
+        }
+
+        // Build result base-first, with derived shadowing base for same-named properties
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<IPropertySymbol>();
+
+        // First pass: collect which property names are shadowed by derived types
+        // (derived = lower index in levels). The derived declaration wins.
+        var shadowedProps = new Dictionary<string, IPropertySymbol>(StringComparer.Ordinal);
+        for (int i = 0; i < levels.Count; i++)
+        {
+            foreach (var prop in levels[i])
+            {
+                // First occurrence (lowest depth / most derived) wins
+                if (!shadowedProps.ContainsKey(prop.Name))
+                    shadowedProps[prop.Name] = prop;
+            }
+        }
+
+        // Second pass: iterate base-first (reverse order), emit using the winning declaration
+        for (int i = levels.Count - 1; i >= 0; i--)
+        {
+            foreach (var prop in levels[i])
+            {
+                if (seen.Add(prop.Name))
+                {
+                    // Use the most-derived declaration (shadowing)
+                    result.Add(shadowedProps[prop.Name]);
+                }
+            }
+        }
+
+        return result;
     }
 
     private static bool CanAssign(ITypeSymbol source, ITypeSymbol dest)

--- a/tests/ForgeMap.Tests/BasicMappingTests.cs
+++ b/tests/ForgeMap.Tests/BasicMappingTests.cs
@@ -1752,3 +1752,195 @@ public class BeforeAndAfterForgeTests
 #endregion
 
 #endregion
+
+#region v1.1 IncludeBaseForge Models and Tests
+
+// v1.1 Inheritance hierarchy test models
+
+public class BaseEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string AuditTrail { get; set; } = string.Empty;
+}
+
+public class BaseDto
+{
+    public int Uid { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string AuditTrail { get; set; } = string.Empty;
+}
+
+public class DerivedEntity : BaseEntity
+{
+    public string Email { get; set; } = string.Empty;
+    public string StatusCode { get; set; } = string.Empty;
+}
+
+public class DerivedDto : BaseDto
+{
+    public string Email { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}
+
+public class LeafEntity : DerivedEntity
+{
+    public int Score { get; set; }
+}
+
+public class LeafDto : DerivedDto
+{
+    public int Score { get; set; }
+}
+
+// Forger with [IncludeBaseForge] — single-level
+[ForgeMap]
+public partial class InheritanceForger
+{
+    [Ignore(nameof(BaseDto.AuditTrail))]
+    [ForgeProperty(nameof(BaseEntity.Id), nameof(BaseDto.Uid))]
+    public partial BaseDto Forge(BaseEntity source);
+
+    [IncludeBaseForge(typeof(BaseEntity), typeof(BaseDto))]
+    public partial DerivedDto Forge(DerivedEntity source);
+}
+
+// Forger with [IncludeBaseForge] — chained through two levels
+[ForgeMap]
+public partial class ChainedInheritanceForger
+{
+    [Ignore(nameof(BaseDto.AuditTrail))]
+    [ForgeProperty(nameof(BaseEntity.Id), nameof(BaseDto.Uid))]
+    public partial BaseDto Forge(BaseEntity source);
+
+    [IncludeBaseForge(typeof(BaseEntity), typeof(BaseDto))]
+    public partial DerivedDto Forge(DerivedEntity source);
+
+    [IncludeBaseForge(typeof(DerivedEntity), typeof(DerivedDto))]
+    public partial LeafDto Forge(LeafEntity source);
+}
+
+// Forger with override: derived [ForgeProperty] overrides inherited [Ignore]
+[ForgeMap]
+public partial class OverrideInheritanceForger
+{
+    [Ignore(nameof(BaseDto.AuditTrail))]
+    [ForgeProperty(nameof(BaseEntity.Id), nameof(BaseDto.Uid))]
+    public partial BaseDto Forge(BaseEntity source);
+
+    [IncludeBaseForge(typeof(BaseEntity), typeof(BaseDto))]
+    [ForgeProperty(nameof(DerivedEntity.StatusCode), nameof(DerivedDto.Status))]
+    public partial DerivedDto Forge(DerivedEntity source);
+}
+
+public class IncludeBaseForgeBasicTests
+{
+    private readonly InheritanceForger _forger = new();
+
+    [Fact]
+    public void IncludeBaseForge_InheritsIgnore_SkipsAuditTrail()
+    {
+        var entity = new DerivedEntity { Id = 1, Name = "Test", AuditTrail = "secret", Email = "a@b.com", StatusCode = "active" };
+        var dto = _forger.Forge(entity);
+
+        dto.AuditTrail.Should().BeEmpty("AuditTrail ignore should be inherited from base");
+    }
+
+    [Fact]
+    public void IncludeBaseForge_InheritsForgeProperty_MapsIdToUid()
+    {
+        var entity = new DerivedEntity { Id = 42, Name = "Test", Email = "a@b.com" };
+        var dto = _forger.Forge(entity);
+
+        dto.Uid.Should().Be(42, "Uid mapping from Id should be inherited from base");
+    }
+
+    [Fact]
+    public void IncludeBaseForge_MapsOwnProperties()
+    {
+        var entity = new DerivedEntity { Id = 1, Name = "Test", Email = "a@b.com" };
+        var dto = _forger.Forge(entity);
+
+        dto.Name.Should().Be("Test");
+        dto.Email.Should().Be("a@b.com");
+    }
+
+    [Fact]
+    public void IncludeBaseForge_BaseMethodStillWorksIndependently()
+    {
+        var entity = new BaseEntity { Id = 10, Name = "Base", AuditTrail = "secret" };
+        var dto = _forger.Forge(entity);
+
+        dto.Uid.Should().Be(10);
+        dto.Name.Should().Be("Base");
+        dto.AuditTrail.Should().BeEmpty();
+    }
+}
+
+public class IncludeBaseForgeChainedTests
+{
+    private readonly ChainedInheritanceForger _forger = new();
+
+    [Fact]
+    public void ChainedIncludeBaseForge_LeafInheritsBaseIgnore()
+    {
+        var entity = new LeafEntity { Id = 1, Name = "Leaf", AuditTrail = "secret", Email = "a@b.com", Score = 100 };
+        var dto = _forger.Forge(entity);
+
+        dto.AuditTrail.Should().BeEmpty("AuditTrail ignore should chain from base through middle to leaf");
+    }
+
+    [Fact]
+    public void ChainedIncludeBaseForge_LeafInheritsForgeProperty()
+    {
+        var entity = new LeafEntity { Id = 99, Name = "Leaf", Email = "a@b.com", Score = 100 };
+        var dto = _forger.Forge(entity);
+
+        dto.Uid.Should().Be(99, "Uid mapping should chain from base through middle to leaf");
+    }
+
+    [Fact]
+    public void ChainedIncludeBaseForge_LeafMapsOwnProperties()
+    {
+        var entity = new LeafEntity { Id = 1, Name = "Leaf", Email = "a@b.com", Score = 100 };
+        var dto = _forger.Forge(entity);
+
+        dto.Score.Should().Be(100);
+        dto.Email.Should().Be("a@b.com");
+    }
+}
+
+public class IncludeBaseForgeOverrideTests
+{
+    private readonly OverrideInheritanceForger _forger = new();
+
+    [Fact]
+    public void OverrideInheritance_ExplicitForgePropertyOverridesInheritedIgnore()
+    {
+        // Base ignores AuditTrail, but derived still inherits this
+        var entity = new DerivedEntity { Id = 1, Name = "Test", AuditTrail = "secret", StatusCode = "active" };
+        var dto = _forger.Forge(entity);
+
+        dto.AuditTrail.Should().BeEmpty("AuditTrail should still be ignored since derived doesn't override it");
+    }
+
+    [Fact]
+    public void OverrideInheritance_DerivedForgePropertyMapsStatusCodeToStatus()
+    {
+        var entity = new DerivedEntity { Id = 1, StatusCode = "active" };
+        var dto = _forger.Forge(entity);
+
+        dto.Status.Should().Be("active", "Explicit [ForgeProperty] on derived should map StatusCode → Status");
+    }
+
+    [Fact]
+    public void OverrideInheritance_InheritedForgePropertyStillWorks()
+    {
+        var entity = new DerivedEntity { Id = 77 };
+        var dto = _forger.Forge(entity);
+
+        dto.Uid.Should().Be(77, "Inherited [ForgeProperty] Id → Uid should still work");
+    }
+}
+
+#endregion

--- a/tests/ForgeMap.Tests/SourceGeneratorTests.cs
+++ b/tests/ForgeMap.Tests/SourceGeneratorTests.cs
@@ -1688,3 +1688,293 @@ public class HookGeneratorTests
 }
 
 #endregion
+
+#region v1.1 IncludeBaseForge Generator Tests
+
+public class IncludeBaseForgeGeneratorTests
+{
+    [Fact]
+    public void Generator_IncludeBaseForge_InheritsIgnore()
+    {
+        var source = """
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class BaseEntity
+                {
+                    public int Id { get; set; }
+                    public string Name { get; set; }
+                    public string Secret { get; set; }
+                }
+
+                public class BaseDto
+                {
+                    public int Id { get; set; }
+                    public string Name { get; set; }
+                    public string Secret { get; set; }
+                }
+
+                public class DerivedEntity : BaseEntity
+                {
+                    public string Email { get; set; }
+                }
+
+                public class DerivedDto : BaseDto
+                {
+                    public string Email { get; set; }
+                }
+
+                [ForgeMap]
+                public partial class TestForger
+                {
+                    [Ignore(nameof(BaseDto.Secret))]
+                    public partial BaseDto Forge(BaseEntity source);
+
+                    [IncludeBaseForge(typeof(BaseEntity), typeof(BaseDto))]
+                    public partial DerivedDto Forge(DerivedEntity source);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Single(generatedTrees);
+
+        var generatedCode = generatedTrees[0].GetText().ToString();
+
+        // The derived method should NOT contain Secret assignment (inherited [Ignore])
+        var derivedMethodStart = generatedCode.IndexOf("DerivedDto Forge(");
+        Assert.True(derivedMethodStart >= 0, "Should contain DerivedDto Forge method");
+        var derivedMethodCode = generatedCode.Substring(derivedMethodStart);
+
+        Assert.DoesNotContain("Secret = source.Secret", derivedMethodCode);
+        Assert.Contains("Email = source.Email", derivedMethodCode);
+    }
+
+    [Fact]
+    public void Generator_IncludeBaseForge_InheritsForgeProperty()
+    {
+        var source = """
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class BaseEntity
+                {
+                    public int Ident { get; set; }
+                    public string Name { get; set; }
+                }
+
+                public class BaseDto
+                {
+                    public int Id { get; set; }
+                    public string Name { get; set; }
+                }
+
+                public class DerivedEntity : BaseEntity
+                {
+                    public string Tag { get; set; }
+                }
+
+                public class DerivedDto : BaseDto
+                {
+                    public string Tag { get; set; }
+                }
+
+                [ForgeMap]
+                public partial class TestForger
+                {
+                    [ForgeProperty(nameof(BaseEntity.Ident), nameof(BaseDto.Id))]
+                    public partial BaseDto Forge(BaseEntity source);
+
+                    [IncludeBaseForge(typeof(BaseEntity), typeof(BaseDto))]
+                    public partial DerivedDto Forge(DerivedEntity source);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        var derivedMethodStart = generatedCode.IndexOf("DerivedDto Forge(");
+        var derivedMethodCode = generatedCode.Substring(derivedMethodStart);
+
+        // Inherited [ForgeProperty] should map Ident → Id
+        Assert.Contains("Id = source.Ident", derivedMethodCode);
+    }
+
+    [Fact]
+    public void Generator_IncludeBaseForge_FM0019_BaseMethodNotFound()
+    {
+        var source = """
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class SomeEntity
+                {
+                    public int Id { get; set; }
+                }
+
+                public class SomeDto
+                {
+                    public int Id { get; set; }
+                }
+
+                public class DerivedEntity : SomeEntity
+                {
+                    public string Tag { get; set; }
+                }
+
+                public class DerivedDto : SomeDto
+                {
+                    public string Tag { get; set; }
+                }
+
+                [ForgeMap]
+                public partial class TestForger
+                {
+                    // No base method for SomeEntity → SomeDto exists!
+                    [IncludeBaseForge(typeof(SomeEntity), typeof(SomeDto))]
+                    public partial DerivedDto Forge(DerivedEntity source);
+                }
+            }
+            """;
+
+        var (diagnostics, _) = RunGenerator(source);
+
+        var fm0019 = diagnostics.FirstOrDefault(d => d.Id == "FM0019");
+        Assert.NotNull(fm0019);
+        Assert.Equal(DiagnosticSeverity.Error, fm0019.Severity);
+    }
+
+    [Fact]
+    public void Generator_IncludeBaseForge_FM0020_TypeMismatch()
+    {
+        var source = """
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class BaseEntity
+                {
+                    public int Id { get; set; }
+                }
+
+                public class BaseDto
+                {
+                    public int Id { get; set; }
+                }
+
+                // UnrelatedEntity does NOT derive from BaseEntity
+                public class UnrelatedEntity
+                {
+                    public int Id { get; set; }
+                    public string Tag { get; set; }
+                }
+
+                public class UnrelatedDto
+                {
+                    public int Id { get; set; }
+                    public string Tag { get; set; }
+                }
+
+                [ForgeMap]
+                public partial class TestForger
+                {
+                    public partial BaseDto Forge(BaseEntity source);
+
+                    // UnrelatedEntity doesn't inherit from BaseEntity — FM0020
+                    [IncludeBaseForge(typeof(BaseEntity), typeof(BaseDto))]
+                    public partial UnrelatedDto Forge(UnrelatedEntity source);
+                }
+            }
+            """;
+
+        var (diagnostics, _) = RunGenerator(source);
+
+        var fm0020 = diagnostics.FirstOrDefault(d => d.Id == "FM0020");
+        Assert.NotNull(fm0020);
+        Assert.Equal(DiagnosticSeverity.Error, fm0020.Severity);
+    }
+
+    [Fact]
+    public void Generator_IncludeBaseForge_Chaining_InheritsAcrossLevels()
+    {
+        var source = """
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class BaseEntity
+                {
+                    public int Id { get; set; }
+                    public string Secret { get; set; }
+                }
+
+                public class BaseDto
+                {
+                    public int Id { get; set; }
+                    public string Secret { get; set; }
+                }
+
+                public class MiddleEntity : BaseEntity
+                {
+                    public string Tag { get; set; }
+                }
+
+                public class MiddleDto : BaseDto
+                {
+                    public string Tag { get; set; }
+                }
+
+                public class LeafEntity : MiddleEntity
+                {
+                    public int Score { get; set; }
+                }
+
+                public class LeafDto : MiddleDto
+                {
+                    public int Score { get; set; }
+                }
+
+                [ForgeMap]
+                public partial class TestForger
+                {
+                    [Ignore(nameof(BaseDto.Secret))]
+                    public partial BaseDto Forge(BaseEntity source);
+
+                    [IncludeBaseForge(typeof(BaseEntity), typeof(BaseDto))]
+                    public partial MiddleDto Forge(MiddleEntity source);
+
+                    [IncludeBaseForge(typeof(MiddleEntity), typeof(MiddleDto))]
+                    public partial LeafDto Forge(LeafEntity source);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+
+        var generatedCode = generatedTrees[0].GetText().ToString();
+
+        // Leaf should inherit the [Ignore] from Base via Middle
+        var leafMethodStart = generatedCode.IndexOf("LeafDto Forge(");
+        Assert.True(leafMethodStart >= 0);
+        var leafMethodCode = generatedCode.Substring(leafMethodStart);
+        Assert.DoesNotContain("Secret = source.Secret", leafMethodCode);
+        Assert.Contains("Score = source.Score", leafMethodCode);
+    }
+
+    private static (IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<SyntaxTree> GeneratedTrees) RunGenerator(string source)
+    {
+        return SourceGeneratorTests.RunGenerator(source);
+    }
+}
+
+#endregion


### PR DESCRIPTION
## Summary

- Add `[IncludeBaseForge(typeof(TBaseSrc), typeof(TBaseDst))]` attribute that inherits `[Ignore]`, `[ForgeProperty]`, `[ForgeFrom]`, and `[ForgeWith]` configuration from a base forge method
- Support multi-level chaining (Base → Middle → Leaf) and explicit override detection
- Fix `GetMappableProperties` to walk `BaseType` chain for inherited property discovery (v1.1 Feature 1 prerequisite)
- Add diagnostics FM0019 (base method not found), FM0020 (type mismatch), FM0021 (inherited attribute overridden)
- 15 new tests covering basic inheritance, chaining, overrides, and error diagnostics

## Test plan

- [x] All 119 tests pass across net8.0, net9.0, net10.0 (104 existing + 15 new)
- [x] Runtime tests verify inherited [Ignore] and [ForgeProperty] apply to derived mappings
- [x] Runtime tests verify multi-level chaining propagates config through Base → Middle → Leaf
- [x] Runtime tests verify explicit attributes on derived methods override inherited config
- [x] Generator tests verify FM0019 emitted when base forge method not found
- [x] Generator tests verify FM0020 emitted when types lack inheritance relationship
- [x] Generator tests verify chained [Ignore] propagates through generated code

Closes part of #19