### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly update checks for NuGet packages and GitHub Actions workflow versions

## Test plan
- [ ] Verify Dependabot picks up the config and opens PRs for outdated dependencies