### PR TITLE
Add Step 0 branch checkout to AutoMapper migration skill

### DIFF
--- a/.claude/skills/automapper-migration/SKILL.md
+++ b/.claude/skills/automapper-migration/SKILL.md
@@ -19,10 +19,11 @@ It contains exact API mappings between AutoMapper and ForgeMap. Consult it for e
 
 ## Step 0: Create a migration branch
 
-Ensure the branch is based on the repo's default branch:
+Ensure the branch is based on the repo's default branch (detect it, don't assume `main`):
 
 ```
-git checkout main && git pull && git checkout -b migrate/automapper-to-forgemap
+DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+git checkout "$DEFAULT" && git pull && git checkout -b migrate/automapper-to-forgemap
 ```
 
 Use a user-specified name if provided.


### PR DESCRIPTION
## Summary
- Adds a "Step 0: Create a migration branch" section — ensures migration work happens on a branch, not directly on `main`/`master`
- Simplifies SKILL.md by removing guidance Claude can derive on its own (nullable annotations, build diagnostic catalog, obvious test failure handling), keeping only non-obvious ForgeMap-specific behaviors and hard rules
- Reduces SKILL.md from 95 to 61 lines

## Test plan
- [ ] Run the automapper-migration skill and verify it creates a branch before making any commits
- [ ] Confirm the 4 incremental commits land on the new branch, not the default branch
- [ ] Verify the routing shim and ForgeMap-specific gotchas are still followed correctly during migration