### PR TITLE
Release v1.3.0: auto-wiring & abstract dispatch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
     <Copyright>Copyright (c) ForgeMap Contributors</Copyright>
 
     <!-- Versioning -->
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
 
     <!-- SourceLink & deterministic builds -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ See [SPEC.md](docs/SPEC.md) for the full specification.
 | **v1.0** | Core generator, property matching, collections, enums, constructor mapping, flattening, `[ReverseForge]`, hooks, DI integration, full diagnostics |
 | **v1.1** | Mapping inheritance, `[IncludeBaseForge]`, `[ForgeAllDerived]` polymorphic dispatch |
 | **v1.2** | Null-safe property assignment: `NullPropertyHandling` with 4 strategies, three-tier config |
+| **v1.3** | Auto-wiring nested & collection mappings, abstract destination dispatch for `[ForgeAllDerived]` |
 
 ## License
 

--- a/docs/SPEC-v1.3-auto-wiring.md
+++ b/docs/SPEC-v1.3-auto-wiring.md
@@ -487,5 +487,5 @@ FM0011 messages distinguish between convention-mapped and auto-wired properties 
 ---
 
 *Specification Version: 1.3*
-*Status: Proposal — the features, diagnostics (including `AutoWireNestedMappings`, FM0024–FM0026), and behavioral changes described here are not yet implemented in the current codebase.*
+*Status: Implemented — all features, diagnostics, and behavioral changes described here are implemented and shipped in v1.3.0.*
 *License: MIT*

--- a/src/ForgeMap.Generator/AnalyzerReleases.Shipped.md
+++ b/src/ForgeMap.Generator/AnalyzerReleases.Shipped.md
@@ -1,6 +1,17 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 1.3.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+FM0024 | ForgeMap | Warning | [ForgeAllDerived] on abstract/interface destination
+FM0025 | ForgeMap | Warning | Ambiguous auto-wire: multiple forge methods match
+FM0026 | ForgeMap | Warning | Auto-wired property has no reverse forge method
+FM0027 | ForgeMap | Disabled | Property auto-wired via forge method
+
 ## Release 1.2.0
 
 ### New Rules

--- a/src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md
@@ -5,8 +5,4 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-FM0024 | ForgeMap | Warning | [ForgeAllDerived] on abstract/interface destination
-FM0025 | ForgeMap | Warning | Ambiguous auto-wire: multiple forge methods match
-FM0026 | ForgeMap | Warning | Auto-wired property has no reverse forge method
-FM0027 | ForgeMap | Disabled | Property auto-wired via forge method
 


### PR DESCRIPTION
## Summary
- Bump version from 1.2.0 to 1.3.0
- Move FM0024–FM0027 diagnostics from AnalyzerReleases.Unshipped.md to Shipped.md under Release 1.3.0
- Update v1.3 spec status from "Proposal" to "Implemented"
- Add v1.3 entry to README version roadmap

## Test plan
- [x] All 210 tests pass on net8.0, net9.0, and net10.0
- [ ] Verify NuGet package builds with correct 1.3.0 version
- [ ] Validate package can be consumed in a test project