### PR TITLE
Use validated symbol names instead of user strings in codegen

### DIFF
--- a/src/ForgeMap.Generator/ForgeCodeEmitter.cs
+++ b/src/ForgeMap.Generator/ForgeCodeEmitter.cs
@@ -2628,11 +2628,11 @@ internal sealed class ForgeCodeEmitter
 
         var beforeForgeHooks = GetBeforeForgeHooks(method)
             .Select(h => ValidateBeforeForgeHook(h, sourceType, forger, context, method))
-            .Where(n => n != null).Select(n => n!)
+            .OfType<string>()
             .ToList();
         var afterForgeHooks = GetAfterForgeHooks(method)
             .Select(h => ValidateAfterForgeHook(h, sourceType, destinationType, forger, context, method))
-            .Where(n => n != null).Select(n => n!)
+            .OfType<string>()
             .ToList();
 
         return new ResolvedMethodConfig(


### PR DESCRIPTION
## Summary
- Defense-in-depth security hardening: after validating method names via Roslyn symbol lookup, emit `IMethodSymbol.Name` instead of the original user-provided attribute string
- **Resolver methods** (`[ForgeFrom]`): 6 call sites changed from `resolverMethodName` to `resolverMethod.Name`
- **ForgeWith methods** (`[ForgeWith]`): 4 call sites changed from `forgingMethodName` to `nestedForgeMethod.Name`
- **Hook methods** (`[BeforeForge]`/`[AfterForge]`): changed `ValidateBeforeForgeHook` and `ValidateAfterForgeHook` to return `string?` (validated symbol name) instead of `bool`, so hook name lists carry validated names through to code generation

Zero behavior change for valid inputs — symbol name and user string are identical for valid C# identifiers.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings
- [x] All 210 tests pass across net8.0, net9.0, net10.0