### PR TITLE
Add security docs for ReverseForge bidirectional mapping risk

### DIFF
--- a/src/ForgeMap.Abstractions/ReverseForgeAttribute.cs
+++ b/src/ForgeMap.Abstractions/ReverseForgeAttribute.cs
@@ -6,10 +6,10 @@ namespace ForgeMap;
 /// Generates a reverse forging method automatically.
 /// </summary>
 /// <remarks>
-/// The reverse method maps all matching properties in the opposite direction.
+/// The reverse method maps all matching writable properties in the opposite direction.
 /// When the forward method maps from an internal model to an external DTO,
-/// the generated reverse method allows the DTO to overwrite every matched property
-/// on the model — including security-sensitive fields such as <c>IsAdmin</c>,
+/// the generated reverse method allows the DTO to overwrite every matched writable
+/// property on the model — including security-sensitive fields such as <c>IsAdmin</c>,
 /// <c>PasswordHash</c>, or audit timestamps. Use <see cref="IgnoreAttribute"/> on
 /// the forward method to exclude properties that should not be writable via the
 /// reverse mapping.


### PR DESCRIPTION
## Summary
- Added XML doc `<remarks>` to `ReverseForgeAttribute` warning that the auto-generated reverse method maps all matched properties back — including security-sensitive fields like `IsAdmin`, `PasswordHash`, or audit timestamps
- Directs developers to use `[Ignore]` on the forward method to exclude properties that should not be writable via the reverse mapping

## Test plan
- [x] `dotnet build` succeeds with 0 warnings
- [x] All 210 tests pass across net8.0, net9.0, net10.0