### PR TITLE
Use symbol names for property paths in generated code

### DIFF
--- a/src/ForgeMap.Generator/ForgeCodeEmitter.cs
+++ b/src/ForgeMap.Generator/ForgeCodeEmitter.cs
@@ -2158,7 +2158,7 @@ internal sealed class ForgeCodeEmitter
             else
             {
                 // Use symbol name when available for defense-in-depth
-                var simpleProp = GetMappableProperties(sourceType).FirstOrDefault(p => p.Name == sourcePath);
+                var simpleProp = sourceProperties.FirstOrDefault(p => p.Name == sourcePath);
                 var safeName = simpleProp?.Name ?? sourcePath;
                 map[destPropName] = ($"source.{safeName}", leafType);
             }


### PR DESCRIPTION
## Summary
- Defense-in-depth: look up property names via `GetMappableProperties` and use `IPropertySymbol.Name` instead of raw user-provided strings from `[ForgeProperty]` attributes when generating source expressions
- **Simple paths**: symbol lookup with fallback to raw string when property not found
- **Nested path parts**: use `prop.Name` instead of the raw `part` string when symbol is resolved
- **Constructor mapping overlay**: same symbol lookup pattern for simple paths

Zero behavior change for valid inputs — symbol name and user string are identical for valid property names.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings
- [x] All 210 tests pass across net8.0, net9.0, net10.0