### PR TITLE
Update automapper-migration skill to run all phases automatically

### DIFF
--- a/.claude/skills/automapper-migration/SKILL.md
+++ b/.claude/skills/automapper-migration/SKILL.md
@@ -100,4 +100,4 @@ Do **not** commit or create branches automatically. Instead, summarize what was 
 **If migration stopped early** (unsupported mapping or build/test failure):
 
 > Phases 1–N completed successfully. Phase N+1 stopped because [reason].
-> The failed phase may have left partial edits in the worktree. Use `git diff` to review, then either revert the failed-phase changes (`git checkout -- <files>`) or selectively stage only the completed phases before committing.
+> The failed phase may have left partial edits in the worktree. Use `git diff` to review all changes. Since earlier phases may have edited the same files, use `git add -p` to selectively stage only the hunks from completed phases — do not blindly revert entire files.


### PR DESCRIPTION
## Summary
- The automapper-migration skill previously stopped after each of the 4 phases to wait for user confirmation, which was disruptive to the workflow
- Updated to proceed through all 4 phases automatically without stopping
- A summary is presented after all phases complete so the developer can review the full set of changes

## Test plan
- [ ] Invoke the automapper-migration skill on a test project and verify it completes all 4 phases without pausing between them
- [ ] Verify the final summary is presented after all phases complete