### PR TITLE
fix: tighten copilot review loop skill with streaming flags and strict iteration rules

### DIFF
--- a/.claude/skills/local-copilot-review-loop/SKILL.md
+++ b/.claude/skills/local-copilot-review-loop/SKILL.md
@@ -47,13 +47,13 @@ node ".claude/skills/local-copilot-review-loop/scripts/copilot-acp-companion.mjs
 
 **IMPORTANT: This is a MANDATORY loop. You MUST keep iterating until a stop condition is met. Do NOT stop after a single iteration just because you fixed or dismissed some findings.**
 
-1. **Detect scope**: Determine `--base` ref. For PRs use the PR base branch. For local work use `main` or `origin/main`. Changes must be committed for `--base` to see them.
+1. **Detect scope**: Determine `--base` ref. For PRs use the PR base branch. For local work use `main` or `origin/main`. Note: `--base` performs a commit-to-commit diff (`base...HEAD`), so staged/unstaged working-tree changes are NOT included — commit first, or omit `--base` to diff against HEAD including working-tree changes.
 2. **Run the companion script** with appropriate `--base` flag
 3. **Process ALL findings from this iteration**:
    - Read the referenced code at the cited line numbers to verify each finding
    - Fix findings that are valid
    - Dismiss findings that are invalid (note why briefly)
-   - Track counts of fixed vs dismissed
+   - Track counts of fixed vs dismissed, and maintain a list of dismissed findings (file, line range, issue summary) for loop detection
 4. **If code was changed**: build and test. If build/test fails, stop and surface the error.
 5. **If code was changed**: commit the fixes (do NOT push unless user asked)
 6. **Re-run the companion script** — this is a NEW ACP session that sees the updated code


### PR DESCRIPTION
## Summary
- Add `--stream` and `--debug` CLI flags to the skill documentation, remove the env-var section
- Clarify mandatory loop semantics: the review loop must iterate until a stop condition is met
- Define "same finding" heuristic for loop detection (file + line ±10 + same issue)
- Require committed changes for `--base` diffing; default to commit-only (no push)

## Test plan
- [ ] Verify skill renders correctly in Claude Code
- [ ] Run `local copilot review` and confirm new flags are recognized
- [ ] Confirm loop iterates properly with updated stop conditions