### PR TITLE
Release v1.4.0: nested existing-target, string↔enum, [ConvertWith]

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
     <Copyright>Copyright (c) ForgeMap Contributors</Copyright>
 
     <!-- Versioning -->
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
 
     <!-- SourceLink & deterministic builds -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ See [SPEC.md](docs/SPEC.md) for the full specification.
 | **v1.1** | Mapping inheritance, `[IncludeBaseForge]`, `[ForgeAllDerived]` polymorphic dispatch |
 | **v1.2** | Null-safe property assignment: `NullPropertyHandling` with 4 strategies, three-tier config |
 | **v1.3** | Auto-wiring nested & collection mappings, abstract destination dispatch for `[ForgeAllDerived]` |
+| **v1.4** | Nested existing-target mapping, automatic string↔enum conversion, `[ConvertWith]` custom type converters |
 
 ## License
 

--- a/src/ForgeMap.Generator/AnalyzerReleases.Shipped.md
+++ b/src/ForgeMap.Generator/AnalyzerReleases.Shipped.md
@@ -1,6 +1,23 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 1.4.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+FM0028 | ForgeMap | Error | ExistingTarget = true is only valid on [UseExistingValue] mutation methods
+FM0029 | ForgeMap | Error | Property has no getter for in-place update
+FM0030 | ForgeMap | Warning | No matching ForgeInto method for nested existing-target
+FM0031 | ForgeMap | Error | CollectionUpdateStrategy.Sync requires KeyProperty
+FM0032 | ForgeMap | Error | KeyProperty not found on element type
+FM0033 | ForgeMap | Disabled | Property auto-converted from string to enum
+FM0034 | ForgeMap | Error | [ConvertWith] type does not implement ITypeConverter
+FM0035 | ForgeMap | Error | [ConvertWith] converter type has no accessible parameterless ctor and no DI
+FM0036 | ForgeMap | Warning | [ConvertWith] takes precedence over [ForgeProperty]/[ForgeFrom]/[ForgeWith]
+FM0037 | ForgeMap | Error | [ConvertWith] member not found or incompatible
+
 ## Release 1.3.0
 
 ### New Rules

--- a/src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md
@@ -5,14 +5,4 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-FM0028 | ForgeMap | Error | ExistingTarget = true is only valid on [UseExistingValue] mutation methods
-FM0029 | ForgeMap | Error | Property has no getter for in-place update
-FM0030 | ForgeMap | Warning | No matching ForgeInto method for nested existing-target
-FM0031 | ForgeMap | Error | CollectionUpdateStrategy.Sync requires KeyProperty
-FM0032 | ForgeMap | Error | KeyProperty not found on element type
-FM0033 | ForgeMap | Disabled | Property auto-converted from string to enum
-FM0034 | ForgeMap | Error | [ConvertWith] type does not implement ITypeConverter
-FM0035 | ForgeMap | Error | [ConvertWith] converter type has no accessible parameterless ctor and no DI
-FM0036 | ForgeMap | Warning | [ConvertWith] takes precedence over [ForgeProperty]/[ForgeFrom]/[ForgeWith]
-FM0037 | ForgeMap | Error | [ConvertWith] member not found or incompatible
 


### PR DESCRIPTION
## Summary
- Bump version from 1.3.0 to 1.4.0 in `Directory.Build.props`
- Ship analyzer rules FM0028–FM0037 (10 new diagnostics) from Unshipped to Shipped
- Update README roadmap with v1.4 features

## v1.4 Features
1. **Nested existing-target mapping** — in-place updates for nested objects (FM0028–FM0032)
2. **Automatic string↔enum conversion** — seamless string-to-enum and enum-to-string mapping (FM0033)
3. **`[ConvertWith]` custom type converters** — plug in custom conversion logic via `ITypeConverter` (FM0034–FM0037)

## Test plan
- [x] Build passes with 0 warnings, 0 errors
- [x] All 264 tests pass on net8.0, net9.0, and net10.0