### PR TITLE
docs: add v1.6 spec for migration-priority features

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -39,7 +39,8 @@
           "SPEC-v1.3-auto-wiring.md",
           "SPEC-v1.4-advanced-mapping.md",
           "SPEC-v1.5-advanced-mapping.md",
-          "SPEC-v1.6-advanced-mapping.md",
+          "SPEC-v1.6-migration-features.md",
+          "SPEC-future-advanced-mapping.md",
           "ForgeMap-vs-AutoMapper-and-Mapperly.md"
         ],
         "src": "../docs",

--- a/docfx/specs/index.md
+++ b/docfx/specs/index.md
@@ -15,7 +15,8 @@ This section contains the internal design specifications for ForgeMap. These doc
 | **v1.3** | [Auto-Wiring](../../docs/SPEC-v1.3-auto-wiring.md) | Auto-wire nested & collection mappings, abstract destination dispatch |
 | **v1.4** | [Advanced Mapping](../../docs/SPEC-v1.4-advanced-mapping.md) | Nested existing-target, string-to-enum, `[ConvertWith]` |
 | **v1.5** | [Advanced Mapping](../../docs/SPEC-v1.5-advanced-mapping.md) | CoalesceToNew, collection coercion, standalone collection methods |
-| **v1.6** | [Advanced Mapping (Planned)](../../docs/SPEC-v1.6-advanced-mapping.md) | Upcoming features |
+| **v1.6** | [Migration Features (Planned)](../../docs/SPEC-v1.6-migration-features.md) | Per-property ConvertWith, type coercions, constructor preference |
+| **Future** | [Advanced Mapping (Planned)](../../docs/SPEC-future-advanced-mapping.md) | Auto-flattening, dictionary mapping |
 
 ## Comparison
 

--- a/docfx/specs/toc.yml
+++ b/docfx/specs/toc.yml
@@ -12,7 +12,9 @@
   href: ../../docs/SPEC-v1.4-advanced-mapping.md
 - name: v1.5 — Advanced Mapping
   href: ../../docs/SPEC-v1.5-advanced-mapping.md
-- name: v1.6 — Advanced Mapping (Planned)
-  href: ../../docs/SPEC-v1.6-advanced-mapping.md
+- name: v1.6 — Migration Features (Planned)
+  href: ../../docs/SPEC-v1.6-migration-features.md
+- name: Future — Advanced Mapping (Planned)
+  href: ../../docs/SPEC-future-advanced-mapping.md
 - name: ForgeMap vs AutoMapper & Mapperly
   href: ../../docs/ForgeMap-vs-AutoMapper-and-Mapperly.md

--- a/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md
+++ b/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md
@@ -14,8 +14,8 @@ The table below compares all three tools across reverse mapping, polymorphic dis
 | **Performance (simple flat mapping)** | ~80 ns | ~16 ns | ~14.5 ns |
 | **License** | RPL-1.5 / commercial (15.0+) | Apache 2.0 | MIT |
 | **Auto reverse mapping** | `.ReverseMap()` | ❌ Manual only | ✅ `[ReverseForge]` with compile-time validation |
-| **Auto-flattening** | ✅ Runtime convention | ✅ Compile-time PascalCase (❌ broken with `init`/`required`) | ✅ Compile-time PascalCase with `init`/`required` support *(planned v1.6)* |
-| **Unflattening** | `.ReverseMap()` (runtime) | Manual `MapProperty` paths | ✅ Auto via `[ReverseForge]` *(planned v1.6)* |
+| **Auto-flattening** | ✅ Runtime convention | ✅ Compile-time PascalCase (❌ broken with `init`/`required`) | ✅ Compile-time PascalCase with `init`/`required` support *(planned, future)* |
+| **Unflattening** | `.ReverseMap()` (runtime) | Manual `MapProperty` paths | ✅ Auto via `[ReverseForge]` *(planned, future)* |
 | **Polymorphic dispatch** | Runtime reflection | Manual `[MapDerivedType]` per type | ✅ Auto-discovered `[ForgeAllDerived]` |
 | **Abstract destination mapping** | Runtime `.As<T>()` | `[MapDerivedType]` dispatch | ✅ Auto-discovered dispatch via `[ForgeAllDerived]` |
 | **Null handling strategies** | `NullSubstitute`, `AllowNullCollections` | `AllowNullPropertyAssignment`, `ThrowOnPropertyMappingNullMismatch`, `ThrowOnMappingNullMismatch` | ✅ 5 strategies (`NullForgiving`, `SkipNull`, `CoalesceToDefault`, `ThrowException`, `CoalesceToNew` in v1.5), 3-tier config |
@@ -27,8 +27,8 @@ The table below compares all three tools across reverse mapping, polymorphic dis
 | **Collection auto-generation** | Runtime | Auto-generated | ✅ Full (`T[]`, `List<T>`, `IEnumerable<T>`, `HashSet<T>`, etc.) |
 | **Inline collection mapping** | N/A | Auto-generated | ✅ Generates inline iteration for collection properties, no explicit method needed |
 | **Nested existing-target update** | `Map(src, dest)` updates nested (runtime) | ❌ Not supported ([#884](https://github.com/riok/mapperly/issues/884), [#1311](https://github.com/riok/mapperly/issues/1311)) | ✅ `ExistingTarget = true` with collection sync strategies *(planned v1.4)* |
-| **Dictionary→Object mapping** | ❌ | ❌ Not supported ([#1309](https://github.com/riok/mapperly/issues/1309)) | ✅ `[ForgeDictionary]` with type-safe conversions *(planned v1.6)* |
-| **Diagnostics** | Runtime exceptions | ~95 diagnostics (RMG001–RMG095) | 27 diagnostics (FM0001–FM0027), 10 more planned for v1.4 (FM0028–FM0037), 8 planned for v1.5 (FM0038–FM0045), 6 planned for v1.6 (FM0046–FM0051) |
+| **Dictionary→Object mapping** | ❌ | ❌ Not supported ([#1309](https://github.com/riok/mapperly/issues/1309)) | ✅ `[ForgeDictionary]` with type-safe conversions *(planned, future)* |
+| **Diagnostics** | Runtime exceptions | ~95 diagnostics (RMG001–RMG095) | 27 diagnostics (FM0001–FM0027), 10 more planned for v1.4 (FM0028–FM0037), 8 planned for v1.5 (FM0038–FM0045), 7 planned for v1.6 (FM0046–FM0052) |
 | **Debuggable generated code** | ❌ | ✅ | ✅ |
 
 ---
@@ -175,7 +175,7 @@ ForgeMap ships with an [**automated migration skill**](../.claude/skills/automap
 
 ## Compile-Time Safety
 
-ForgeMap currently provides **27 diagnostic rules** (FM0001–FM0027) that catch mapping errors at compile time, with an additional 10 rules (FM0028–FM0037) planned for v1.4, 8 rules (FM0038–FM0045) planned for v1.5, and 6 rules (FM0046–FM0051) planned for v1.6:
+ForgeMap currently provides **27 diagnostic rules** (FM0001–FM0027) that catch mapping errors at compile time, with an additional 10 rules (FM0028–FM0037) planned for v1.4, 8 rules (FM0038–FM0045) planned for v1.5, and 7 rules (FM0046–FM0052) planned for v1.6:
 
 - **Structural errors** — non-partial class/method, missing constructors, circular dependencies
 - **Mapping gaps** — unmapped source/destination properties, unmatched constructor parameters
@@ -187,7 +187,7 @@ These diagnostics surface in the IDE as you type, catching mapping errors before
 
 ### 6. Auto-Flattening with `init`/`required` Support
 
-Mapperly supports auto-flattening (`Order.Customer.Name` → `CustomerName`) but has been [broken for `init`/`required` properties since 2023](https://github.com/riok/mapperly/issues/643). ForgeMap v1.6 will build flattening from scratch with full `init`/`required` awareness — these properties are routed to object initializers automatically:
+Mapperly supports auto-flattening (`Order.Customer.Name` → `CustomerName`) but has been [broken for `init`/`required` properties since 2023](https://github.com/riok/mapperly/issues/643). ForgeMap will build flattening from scratch with full `init`/`required` awareness — these properties are routed to object initializers automatically:
 
 ```csharp
 class OrderDto {
@@ -218,7 +218,7 @@ For collection properties, `CollectionUpdateStrategy.Sync` with `KeyProperty` ma
 
 ### 8. Dictionary-to-Typed-Object Mapping
 
-Neither AutoMapper nor Mapperly support mapping `Dictionary<string, object?>` to typed objects ([Mapperly #1309](https://github.com/riok/mapperly/issues/1309), 10👍). ForgeMap v1.6 will add `[ForgeDictionary]` for compile-time, zero-reflection dictionary mapping:
+Neither AutoMapper nor Mapperly support mapping `Dictionary<string, object?>` to typed objects ([Mapperly #1309](https://github.com/riok/mapperly/issues/1309), 10👍). ForgeMap will add `[ForgeDictionary]` for compile-time, zero-reflection dictionary mapping:
 
 ```csharp
 [ForgeDictionary(KeyMatching = PropertyMatching.ByNameCaseInsensitive)]
@@ -238,10 +238,10 @@ Supports configurable key matching (case-sensitive/insensitive), missing key beh
 | `Entity ↔ DTO` round-trips | `[ReverseForge]` auto-generates the inverse |
 | Deep inheritance hierarchies | `[ForgeAllDerived]` auto-discovers subtypes |
 | Mixed nullability across large codebases | 5 strategies (including `CoalesceToNew` in v1.5), per-property control |
-| Nested object flattening | Auto-flattening with `init`/`required` support *(planned v1.6)* |
+| Nested object flattening | Auto-flattening with `init`/`required` support *(planned, future)* |
 | EF Core in-place entity updates | `ExistingTarget = true` with collection sync *(shipped in v1.4)* |
-| Dynamic / dictionary data sources | `[ForgeDictionary]` with compile-time type safety *(planned v1.6)* |
+| Dynamic / dictionary data sources | `[ForgeDictionary]` with compile-time type safety *(planned, future)* |
 | Migrating from AutoMapper | 1:1 concept mapping, automated migration skill |
 | Declarative lifecycle hooks | `[BeforeForge]` / `[AfterForge]` with ordered execution |
 
-ForgeMap provides comparable performance to Mapperly with additional support for auto-discovered polymorphism, declarative hooks, granular null handling, and a direct migration path from AutoMapper, including v1.4 features like EF Core-friendly nested updates, string-to-enum auto-conversion, and `[ConvertWith]`, plus v1.5 features like `CoalesceToNew`, collection type coercion, and standalone collection methods, with v1.6 features like auto-flattening with `init`/`required` support and dictionary mapping planned.
+ForgeMap provides comparable performance to Mapperly with additional support for auto-discovered polymorphism, declarative hooks, granular null handling, and a direct migration path from AutoMapper, including v1.4 features like EF Core-friendly nested updates, string-to-enum auto-conversion, and `[ConvertWith]`, plus v1.5 features like `CoalesceToNew`, collection type coercion, and standalone collection methods, with v1.6 features like per-property `ConvertWith`, built-in type coercions, and constructor preference for get-only types planned, and future features like auto-flattening and dictionary mapping on the roadmap.

--- a/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md
+++ b/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md
@@ -28,7 +28,7 @@ The table below compares all three tools across reverse mapping, polymorphic dis
 | **Inline collection mapping** | N/A | Auto-generated | ✅ Generates inline iteration for collection properties, no explicit method needed |
 | **Nested existing-target update** | `Map(src, dest)` updates nested (runtime) | ❌ Not supported ([#884](https://github.com/riok/mapperly/issues/884), [#1311](https://github.com/riok/mapperly/issues/1311)) | ✅ `ExistingTarget = true` with collection sync strategies *(shipped in v1.4)* |
 | **Dictionary→Object mapping** | ❌ | ❌ Not supported ([#1309](https://github.com/riok/mapperly/issues/1309)) | ✅ `[ForgeDictionary]` with type-safe conversions *(planned, future)* |
-| **Diagnostics** | Runtime exceptions | ~95 diagnostics (RMG001–RMG095) | 27 diagnostics (FM0001–FM0027), 10 more planned for v1.4 (FM0028–FM0037), 8 planned for v1.5 (FM0038–FM0045), 7 planned for v1.6 (FM0046–FM0052) |
+| **Diagnostics** | Runtime exceptions | ~95 diagnostics (RMG001–RMG095) | 45 diagnostics (FM0001–FM0045 shipped in v1.0–v1.5), 7 planned for v1.6 (FM0046–FM0052) |
 | **Debuggable generated code** | ❌ | ✅ | ✅ |
 
 ---
@@ -175,7 +175,7 @@ ForgeMap ships with an [**automated migration skill**](../.claude/skills/automap
 
 ## Compile-Time Safety
 
-ForgeMap currently provides **27 diagnostic rules** (FM0001–FM0027) that catch mapping errors at compile time, with an additional 10 rules (FM0028–FM0037) planned for v1.4, 8 rules (FM0038–FM0045) planned for v1.5, and 7 rules (FM0046–FM0052) planned for v1.6:
+ForgeMap currently provides **45 diagnostic rules** (FM0001–FM0045, shipped in v1.0–v1.5) that catch mapping errors at compile time, with 7 additional rules (FM0046–FM0052) planned for v1.6:
 
 - **Structural errors** — non-partial class/method, missing constructors, circular dependencies
 - **Mapping gaps** — unmapped source/destination properties, unmatched constructor parameters

--- a/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md
+++ b/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md
@@ -26,7 +26,7 @@ The table below compares all three tools across reverse mapping, polymorphic dis
 | **Mutation mapping** | `Map(src, dest)` | `Map(src, dest)` | ✅ Partial-method mutation pattern with `[UseExistingValue]` destination |
 | **Collection auto-generation** | Runtime | Auto-generated | ✅ Full (`T[]`, `List<T>`, `IEnumerable<T>`, `HashSet<T>`, etc.) |
 | **Inline collection mapping** | N/A | Auto-generated | ✅ Generates inline iteration for collection properties, no explicit method needed |
-| **Nested existing-target update** | `Map(src, dest)` updates nested (runtime) | ❌ Not supported ([#884](https://github.com/riok/mapperly/issues/884), [#1311](https://github.com/riok/mapperly/issues/1311)) | ✅ `ExistingTarget = true` with collection sync strategies *(planned v1.4)* |
+| **Nested existing-target update** | `Map(src, dest)` updates nested (runtime) | ❌ Not supported ([#884](https://github.com/riok/mapperly/issues/884), [#1311](https://github.com/riok/mapperly/issues/1311)) | ✅ `ExistingTarget = true` with collection sync strategies *(shipped in v1.4)* |
 | **Dictionary→Object mapping** | ❌ | ❌ Not supported ([#1309](https://github.com/riok/mapperly/issues/1309)) | ✅ `[ForgeDictionary]` with type-safe conversions *(planned, future)* |
 | **Diagnostics** | Runtime exceptions | ~95 diagnostics (RMG001–RMG095) | 27 diagnostics (FM0001–FM0027), 10 more planned for v1.4 (FM0028–FM0037), 8 planned for v1.5 (FM0038–FM0045), 7 planned for v1.6 (FM0046–FM0052) |
 | **Debuggable generated code** | ❌ | ✅ | ✅ |

--- a/docs/SPEC-future-advanced-mapping.md
+++ b/docs/SPEC-future-advanced-mapping.md
@@ -1,8 +1,8 @@
-# ForgeMap v1.6 Specification — Advanced Mapping
+# ForgeMap Specification — Advanced Mapping (Future)
 
 ## Overview
 
-v1.6 delivers two advanced features deferred from the v1.4 plan through v1.5 to prioritize migration-driven issues.
+This specification covers two advanced features deferred from v1.4 through v1.6 to prioritize migration-driven issues. These features are planned for a future version.
 
 | # | Feature | Issue | Status |
 |---|---------|-------|--------|
@@ -199,17 +199,17 @@ public Order Forge(OrderDto source)
 ```
 
 **Unflattening constraints:**
-- Intermediate types must have accessible parameterless constructors (or constructor parameters matching the properties). Emit **FM0047** if not constructible
+- Intermediate types must have accessible parameterless constructors (or constructor parameters matching the properties). Emit **FM0054** if not constructible
 - When multiple destination properties unflatten into the same intermediate object, they are grouped into a single object initializer
-- `[ReverseForge]` unflattening is best-effort — emit **FM0048** (warning) for any property that cannot be unflattened, with a suggestion to add explicit `[ForgeProperty]` on the reverse method
+- `[ReverseForge]` unflattening is best-effort — emit **FM0055** (warning) for any property that cannot be unflattened, with a suggestion to add explicit `[ForgeProperty]` on the reverse method
 
 ### Diagnostics
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| **FM0046** | Info | Property '{0}' auto-flattened from '{1}' (disabled by default; enable via `.editorconfig`) |
-| **FM0047** | Error | Unflattening requires type '{0}' to have an accessible constructor, but none was found |
-| **FM0048** | Warning | Auto-flattened property '{0}' cannot be unflattened for `[ReverseForge]`: {reason} |
+| **FM0053** | Info | Property '{0}' auto-flattened from '{1}' (disabled by default; enable via `.editorconfig`) |
+| **FM0054** | Error | Unflattening requires type '{0}' to have an accessible constructor, but none was found |
+| **FM0055** | Warning | Auto-flattened property '{0}' cannot be unflattened for `[ReverseForge]`: {reason} |
 
 ### Interaction with Existing Features
 
@@ -224,7 +224,7 @@ public Order Forge(OrderDto source)
 
 ### Competitor Comparison
 
-| Aspect | AutoMapper | Mapperly | ForgeMap v1.6 (planned) |
+| Aspect | AutoMapper | Mapperly | ForgeMap (planned) |
 |--------|-----------|---------|---------------|
 | Auto-flattening | ✅ Runtime convention | ✅ Compile-time PascalCase | ✅ Compile-time PascalCase |
 | `init`/`required` properties | ✅ Runtime (since v13) | ❌ Broken (#643) | ✅ Object initializer routing |
@@ -232,7 +232,7 @@ public Order Forge(OrderDto source)
 | Opt-out | `.DisableCtorValidation()` | No opt-out | `AutoFlatten = false` |
 | Case sensitivity control | Always case-insensitive | Case-insensitive | Follows `PropertyMatching` |
 | Null-safe paths | Runtime null checks | Compile-time `?.` chains | Compile-time `?.` chains |
-| Diagnostic visibility | None (runtime only) | Compile-time | FM0046 info (opt-in) |
+| Diagnostic visibility | None (runtime only) | Compile-time | FM0053 info (opt-in) |
 
 ---
 
@@ -448,7 +448,7 @@ The generator applies the following conversion hierarchy for each destination pr
 | 6 | Auto-wired forge method | `value is SourceType s ? Forge(s) : /* skip/throw */` | Complex nested types |
 | 7 | `ToString()` | `value?.ToString()` | Any → string (fallback) |
 
-The generator picks the **first applicable** strategy at compile time. If no strategy applies, the property is skipped and **FM0050** is emitted.
+The generator picks the **first applicable** strategy at compile time. If no strategy applies, the property is skipped and **FM0057** is emitted.
 
 For strategies that use framework conversion helpers (e.g., `Convert.ToXxx`, `Enum.Parse`), any exceptions thrown by those helpers (`FormatException`, `OverflowException`, `ArgumentException`, etc.) are propagated as-is; the generator does **not** catch and wrap them into a uniform `InvalidCastException`.
 
@@ -504,9 +504,9 @@ public Dictionary<string, object?> Forge(UserDto source)
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| **FM0049** | Error | `[ForgeDictionary]` source parameter must be `Dictionary<string, object?>`, `IDictionary<string, object?>`, or `IReadOnlyDictionary<string, object?>` |
-| **FM0050** | Warning | Destination property '{0}' of type '{1}' has no applicable conversion from `object?`. The property will be skipped |
-| **FM0051** | Info | Property '{0}' mapped from dictionary key '{1}' with conversion '{2}' (disabled by default) |
+| **FM0056** | Error | `[ForgeDictionary]` source parameter must be `Dictionary<string, object?>`, `IDictionary<string, object?>`, or `IReadOnlyDictionary<string, object?>` |
+| **FM0057** | Warning | Destination property '{0}' of type '{1}' has no applicable conversion from `object?`. The property will be skipped |
+| **FM0058** | Info | Property '{0}' mapped from dictionary key '{1}' with conversion '{2}' (disabled by default) |
 
 ### Behavioral Contract
 
@@ -523,7 +523,7 @@ public Dictionary<string, object?> Forge(UserDto source)
 
 ### Competitor Comparison
 
-| Aspect | AutoMapper | Mapperly | ForgeMap v1.6 (planned) |
+| Aspect | AutoMapper | Mapperly | ForgeMap (planned) |
 |--------|-----------|---------|---------------|
 | Dictionary→Object | ❌ Not supported | ❌ Not supported (#1309) | ✅ `[ForgeDictionary]` |
 | Case-insensitive keys | N/A | N/A | ✅ `KeyMatching` option |
@@ -538,12 +538,12 @@ public Dictionary<string, object?> Forge(UserDto source)
 
 | Code | Severity | Category | Feature | Description |
 |------|----------|----------|---------|-------------|
-| FM0046 | Info | `ForgeMap` | Auto-flattening | Property '{0}' auto-flattened from '{1}' (disabled by default) |
-| FM0047 | Error | `ForgeMap` | Auto-flattening | Unflattening requires type '{0}' to have an accessible constructor |
-| FM0048 | Warning | `ForgeMap` | Auto-flattening | Auto-flattened property '{0}' cannot be unflattened for `[ReverseForge]`: {reason} |
-| FM0049 | Error | `ForgeMap` | `[ForgeDictionary]` | Source parameter must be `Dictionary<string, object?>`, `IDictionary<string, object?>`, or `IReadOnlyDictionary<string, object?>` |
-| FM0050 | Warning | `ForgeMap` | `[ForgeDictionary]` | Destination property '{0}' of type '{1}' has no applicable conversion from `object?` |
-| FM0051 | Info | `ForgeMap` | `[ForgeDictionary]` | Property '{0}' mapped from dictionary key '{1}' with conversion '{2}' (disabled by default) |
+| FM0053 | Info | `ForgeMap` | Auto-flattening | Property '{0}' auto-flattened from '{1}' (disabled by default) |
+| FM0054 | Error | `ForgeMap` | Auto-flattening | Unflattening requires type '{0}' to have an accessible constructor |
+| FM0055 | Warning | `ForgeMap` | Auto-flattening | Auto-flattened property '{0}' cannot be unflattened for `[ReverseForge]`: {reason} |
+| FM0056 | Error | `ForgeMap` | `[ForgeDictionary]` | Source parameter must be `Dictionary<string, object?>`, `IDictionary<string, object?>`, or `IReadOnlyDictionary<string, object?>` |
+| FM0057 | Warning | `ForgeMap` | `[ForgeDictionary]` | Destination property '{0}' of type '{1}' has no applicable conversion from `object?` |
+| FM0058 | Info | `ForgeMap` | `[ForgeDictionary]` | Property '{0}' mapped from dictionary key '{1}' with conversion '{2}' (disabled by default) |
 
 ---
 
@@ -558,7 +558,6 @@ public Dictionary<string, object?> Forge(UserDto source)
 
 ---
 
-*Specification Version: 1.6 (2026-04-07)*
+*Specification Version: Future (deferred from v1.4 → v1.5 → v1.6)*
 *Status: Planned*
-*Deferred from: v1.4 → v1.5 → v1.6*
 *License: MIT*

--- a/docs/SPEC-v1.4-advanced-mapping.md
+++ b/docs/SPEC-v1.4-advanced-mapping.md
@@ -10,14 +10,14 @@ v1.4 delivers nested existing-target mapping plus two AutoMapper migration pain 
 | 2 | Auto-convert string→enum | [#80](https://github.com/superyyrrzz/ForgeMap/issues/80) | **Shipped** |
 | 3 | `[ConvertWith]` code generation | [#81](https://github.com/superyyrrzz/ForgeMap/issues/81) | **Shipped** |
 
-### Deferred to v1.6
+### Deferred to Future Version
 
-The following features were originally planned for v1.4 but have been deferred (v1.4 → v1.5 → v1.6) to prioritize migration-driven issues:
+The following features were originally planned for v1.4 but have been deferred (v1.4 → v1.5 → v1.6 → future) to prioritize migration-driven issues:
 
 | Feature | Issue | Notes |
 |---------|-------|-------|
-| Auto-flattening with `init`/`required` support | [#82](https://github.com/superyyrrzz/ForgeMap/issues/82) | See [SPEC-v1.6-advanced-mapping.md](SPEC-v1.6-advanced-mapping.md) |
-| Dictionary-to-typed-object mapping (`[ForgeDictionary]`) | [#83](https://github.com/superyyrrzz/ForgeMap/issues/83) | See [SPEC-v1.6-advanced-mapping.md](SPEC-v1.6-advanced-mapping.md) |
+| Auto-flattening with `init`/`required` support | [#82](https://github.com/superyyrrzz/ForgeMap/issues/82) | See [SPEC-future-advanced-mapping.md](SPEC-future-advanced-mapping.md) |
+| Dictionary-to-typed-object mapping (`[ForgeDictionary]`) | [#83](https://github.com/superyyrrzz/ForgeMap/issues/83) | See [SPEC-future-advanced-mapping.md](SPEC-future-advanced-mapping.md) |
 
 ---
 
@@ -626,5 +626,5 @@ v1.4 introduces no required source changes and no API-surface breaks. Three beha
 *Specification Version: 1.4 (revised 2026-04-03)*
 *Status: Complete — all features shipped*
 *v1.5: [SPEC-v1.5-advanced-mapping.md](SPEC-v1.5-advanced-mapping.md)*
-*v1.6 deferred features: [SPEC-v1.6-advanced-mapping.md](SPEC-v1.6-advanced-mapping.md)*
+*Deferred features: [SPEC-future-advanced-mapping.md](SPEC-future-advanced-mapping.md)*
 *License: MIT*

--- a/docs/SPEC-v1.5-advanced-mapping.md
+++ b/docs/SPEC-v1.5-advanced-mapping.md
@@ -11,14 +11,14 @@ v1.5 prioritizes four features driven by real-world AutoMapper → ForgeMap migr
 | 3 | Standalone collection mapping methods | [#89](https://github.com/superyyrrzz/ForgeMap/issues/89) | Medium | Planned |
 | 4 | `[AfterForge]` migration pattern & diagnostics | [#93](https://github.com/superyyrrzz/ForgeMap/issues/93) | Low | Planned |
 
-### Deferred to v1.6
+### Deferred to Future Version
 
-The following features were originally planned for v1.5 but have been moved to v1.6 to prioritize migration-blocking issues #89, #90, #91, and #93:
+The following features were originally planned for v1.5 but have been moved to a future version to prioritize migration-blocking issues #89, #90, #91, and #93:
 
 | Feature | Issue | Notes |
 |---------|-------|-------|
-| Auto-flattening with `init`/`required` support | [#82](https://github.com/superyyrrzz/ForgeMap/issues/82) | See [SPEC-v1.6-advanced-mapping.md](SPEC-v1.6-advanced-mapping.md) |
-| Dictionary-to-typed-object mapping (`[ForgeDictionary]`) | [#83](https://github.com/superyyrrzz/ForgeMap/issues/83) | See [SPEC-v1.6-advanced-mapping.md](SPEC-v1.6-advanced-mapping.md) |
+| Auto-flattening with `init`/`required` support | [#82](https://github.com/superyyrrzz/ForgeMap/issues/82) | See [SPEC-future-advanced-mapping.md](SPEC-future-advanced-mapping.md) |
+| Dictionary-to-typed-object mapping (`[ForgeDictionary]`) | [#83](https://github.com/superyyrrzz/ForgeMap/issues/83) | See [SPEC-future-advanced-mapping.md](SPEC-future-advanced-mapping.md) |
 
 ---
 
@@ -766,5 +766,5 @@ v1.5 introduces no required source changes and no API-surface breaks. Four behav
 
 *Specification Version: 1.5 (2026-04-07)*
 *Status: Planned*
-*Deferred features: [SPEC-v1.6-advanced-mapping.md](SPEC-v1.6-advanced-mapping.md)*
+*Deferred features: [SPEC-future-advanced-mapping.md](SPEC-future-advanced-mapping.md)*
 *License: MIT*

--- a/docs/SPEC-v1.6-migration-features.md
+++ b/docs/SPEC-v1.6-migration-features.md
@@ -42,7 +42,7 @@ private static FileType ResolveType(Source s)
 
 ### Design
 
-When converting `string` or `string?` to an enum type, the generator wraps the conversion in a `string.IsNullOrEmpty` guard. This applies to both `StringToEnumConversion.Parse` and `StringToEnumConversion.TryParse` modes. The guard returns `default(TEnum)` for null/empty strings.
+When converting `string` or `string?` to an enum type, the generator wraps the conversion in a `string.IsNullOrEmpty` guard. This applies to both `StringToEnumConversion.Parse` and `StringToEnumConversion.TryParse` modes. For non-nullable enum destinations, the guard returns `default(TEnum)` for null/empty strings. For nullable enum destinations (`TEnum?`), it returns `null`.
 
 This is a behavioral change from v1.5 where `Enum.Parse` was called unconditionally. The new behavior is safer — `Enum.Parse(null)` and `Enum.Parse("")` are always errors, never intentional.
 
@@ -197,9 +197,11 @@ The detection is based on comparing element types after stripping nullable annot
 // Note: same collection wrapper type — only element nullability differs.
 
 // Strategy: materialize with widened value type
-dest.Metadata = source.Metadata?.ToDictionary(
-    __kv => __kv.Key,
-    __kv => (object?)__kv.Value);
+dest.Metadata = source.Metadata is { } __v_Metadata
+    ? __v_Metadata.ToDictionary(
+        __kv => __kv.Key,
+        __kv => (object?)__kv.Value)
+    : null!;
 ```
 
 **Dictionary value nullability narrowing** (`object?` → `object`):
@@ -208,9 +210,11 @@ dest.Metadata = source.Metadata?.ToDictionary(
 // IReadOnlyDictionary<string, object?> → IDictionary<string, object>
 // Narrowing: nullable → non-nullable requires filtering or asserting.
 // Use NullForgiving (!) since the user explicitly declared the destination as non-nullable.
-dest.Metadata = source.Metadata?.ToDictionary(
-    __kv => __kv.Key,
-    __kv => __kv.Value!);
+dest.Metadata = source.Metadata is { } __v_Metadata
+    ? __v_Metadata.ToDictionary(
+        __kv => __kv.Key,
+        __kv => __kv.Value!)
+    : null!;
 ```
 
 **List/sequence element nullability widening** (`T` → `T?`):

--- a/docs/SPEC-v1.6-migration-features.md
+++ b/docs/SPEC-v1.6-migration-features.md
@@ -1031,7 +1031,7 @@ All v1.6 features work within the existing attribute surface (one new property o
 
 ### From v1.5 to v1.6
 
-v1.6 introduces two behavioral changes that may affect existing forgers:
+v1.6 introduces several behavioral changes that may affect existing forgers:
 
 1. **String→enum null/empty handling (Feature 1)** — `Enum.Parse` on null/empty strings now returns `default(TEnum)` instead of throwing. This is safer but may change behavior for projects that relied on the exception. For projects using `StringToEnumConversion.TryParse`, the generated code now includes an explicit `IsNullOrEmpty` guard for consistency, though runtime behavior is unchanged since `TryParse` already returns `false` for null/empty. **To preserve v1.5 behavior**: use `[ForgeFrom]` with an explicit resolver that calls `Enum.Parse` without the guard.
 
@@ -1039,7 +1039,9 @@ v1.6 introduces two behavioral changes that may affect existing forgers:
 
 3. **Nullable collection coercion (Feature 2)** — Properties that previously triggered CS8620 will now generate nullable-safe coercion code. This should only eliminate warnings, not change runtime behavior.
 
-4. **Per-property ConvertWith (Feature 3)** and **Built-in type coercions (Feature 4)** are opt-in — no behavior change unless explicitly used.
+4. **Built-in type coercions (Feature 4)** — `DateTimeOffset → DateTime` and allowlisted generic wrapper unwrapping (`StringEnum<T> → T`) are applied automatically when matching type pairs are detected. Properties that previously required manual methods or were skipped (FM0006) will now be auto-mapped. **To preserve v1.5 behavior**: use `[Ignore]` on the affected property, or use `[ForgeProperty(ConvertWith = ...)]` to control the conversion explicitly.
+
+5. **Per-property ConvertWith (Feature 3)** is opt-in — no behavior change unless explicitly used via `[ForgeProperty(ConvertWith = ...)]`.
 
 ---
 

--- a/docs/SPEC-v1.6-migration-features.md
+++ b/docs/SPEC-v1.6-migration-features.md
@@ -1,0 +1,1061 @@
+# ForgeMap v1.6 Specification — Migration-Priority Features (Part 2)
+
+## Overview
+
+v1.6 addresses five pain points identified during the OpenPublishing.Build AutoMapper migration. These gaps collectively forced ~300+ lines of manual mapping code across 16 methods in `PullRequestForger` that ForgeMap should eliminate. Features are ordered from smallest to largest scope.
+
+| # | Feature | Issue | Effort | Status |
+|---|---------|-------|--------|--------|
+| 1 | Null/empty string→enum: default instead of throwing | [#109](https://github.com/superyyrrzz/ForgeMap/issues/109) | Low | Planned |
+| 2 | Nullable-safe collection coercion (CS8620) | [#110](https://github.com/superyyrrzz/ForgeMap/issues/110) | Low | Planned |
+| 3 | Per-property `ConvertWith` on `[ForgeProperty]` | [#111](https://github.com/superyyrrzz/ForgeMap/issues/111) | Medium | Planned |
+| 4 | Built-in type coercions (`DateTimeOffset→DateTime`, generic wrapper unwrapping) | [#112](https://github.com/superyyrrzz/ForgeMap/issues/112) | Medium | Planned |
+| 5 | Constructor preference for get-only destination types | [#108](https://github.com/superyyrrzz/ForgeMap/issues/108) | Medium | Planned |
+
+### Deferred to Future Version
+
+The following features were originally envisioned for v1.6 but have been moved to a future version to prioritize these migration-blocking issues:
+
+| Feature | Issue | Notes |
+|---------|-------|-------|
+| Auto-flattening with `init`/`required` support | [#82](https://github.com/superyyrrzz/ForgeMap/issues/82) | See [SPEC-future-advanced-mapping.md](SPEC-future-advanced-mapping.md) |
+| Dictionary-to-typed-object mapping (`[ForgeDictionary]`) | [#83](https://github.com/superyyrrzz/ForgeMap/issues/83) | See [SPEC-future-advanced-mapping.md](SPEC-future-advanced-mapping.md) |
+
+---
+
+## Feature 1: Null/Empty String→Enum Default Coercion
+
+> **Issue:** [#109](https://github.com/superyyrrzz/ForgeMap/issues/109)
+
+### Problem
+
+ForgeMap v1.4 added automatic `string ↔ enum` conversion. However, when the source string is `null` or empty, the generated `Enum.Parse<T>()` call throws `ArgumentNullException` or `ArgumentException`. This is common with REST client models (AutoRest, NSwag) that represent enums as nullable strings. Users must write a manual `[ForgeFrom]` resolver for every such property:
+
+```csharp
+// Manual resolver required today for every nullable-string→enum property:
+[ForgeFrom(nameof(Dest.Type), nameof(ResolveType))]
+public partial Dest ForgeDest(Source source);
+
+private static FileType ResolveType(Source s)
+    => string.IsNullOrEmpty(s.Type) ? default : Enum.Parse<FileType>(s.Type);
+```
+
+### Design
+
+When converting `string` or `string?` to an enum type, the generator wraps the conversion in a `string.IsNullOrEmpty` guard. This applies to both `StringToEnum.Parse` and `StringToEnum.TryParse` modes. The guard returns `default(TEnum)` for null/empty strings.
+
+This is a behavioral change from v1.5 where `Enum.Parse` was called unconditionally. The new behavior is safer — `Enum.Parse(null)` and `Enum.Parse("")` are always errors, never intentional.
+
+### Generated Code
+
+**`StringToEnum.Parse` (default):**
+
+```csharp
+// v1.5: Enum.Parse throws on null/empty
+dest.Type = (FileType)global::System.Enum.Parse(typeof(FileType), source.Type, true);
+
+// v1.6: null/empty guard with default fallback
+dest.Type = string.IsNullOrEmpty(source.Type)
+    ? default(FileType)
+    : (FileType)global::System.Enum.Parse(typeof(FileType), source.Type, true);
+```
+
+**`StringToEnum.TryParse`:**
+
+```csharp
+// v1.5: TryParse already handles null gracefully (returns false, default),
+// but empty string "" parses to 0 silently which may be surprising.
+// v1.6: explicit guard for consistency
+dest.Type = !string.IsNullOrEmpty(source.Type)
+    && global::System.Enum.TryParse<FileType>(source.Type, true, out var __enumVal_Type)
+    ? __enumVal_Type
+    : default(FileType);
+```
+
+**Nullable string → non-nullable enum with `NullPropertyHandling`:**
+
+The `string.IsNullOrEmpty` guard is applied *within* the existing null-handling wrapper. When the source is `string?` and destination is a non-nullable enum, `NullPropertyHandling` governs the outer null check; the empty-string guard is an inner concern:
+
+```csharp
+// NullPropertyHandling.NullForgiving + Parse (default)
+dest.Type = string.IsNullOrEmpty(source.Type!)
+    ? default(FileType)
+    : (FileType)global::System.Enum.Parse(typeof(FileType), source.Type!, true);
+
+// NullPropertyHandling.ThrowException + Parse
+dest.Type = source.Type is null
+    ? throw new global::System.ArgumentNullException("source.Type")
+    : string.IsNullOrEmpty(source.Type)
+        ? default(FileType)
+        : (FileType)global::System.Enum.Parse(typeof(FileType), source.Type, true);
+
+// NullPropertyHandling.SkipNull (non-init property)
+if (source.Type is { Length: > 0 } __enumStr_Type)
+    dest.Type = (FileType)global::System.Enum.Parse(typeof(FileType), __enumStr_Type, true);
+```
+
+**Nullable string → nullable enum:**
+
+```csharp
+// string? → FileType?
+dest.Type = string.IsNullOrEmpty(source.Type)
+    ? (FileType?)null
+    : (FileType)global::System.Enum.Parse(typeof(FileType), source.Type, true);
+```
+
+**Constructor parameters:**
+
+The same guard applies when string→enum conversion is used for constructor parameter matching:
+
+```csharp
+var __result = new Dest(
+    type: string.IsNullOrEmpty(source.Type)
+        ? default(FileType)
+        : (FileType)global::System.Enum.Parse(typeof(FileType), source.Type, true)
+);
+```
+
+### Interaction with Existing Features
+
+| Feature | Interaction |
+|---------|-------------|
+| `StringToEnum.Parse` | Guard wraps `Enum.Parse` — returns `default(TEnum)` for null/empty instead of throwing |
+| `StringToEnum.TryParse` | Guard wraps `TryParse` — explicit `IsNullOrEmpty` check for consistency (empty string is no longer silently parsed to 0) |
+| `StringToEnum.None` | No change — auto-conversion disabled, guard not emitted |
+| `NullPropertyHandling` | Works inside existing null-handling wrappers — the empty-string guard is an orthogonal concern |
+| `[ForgeProperty]` | Applies to explicitly mapped string→enum pairs |
+| `[ForgeFrom]` | Resolver takes precedence — guard not emitted when a resolver is defined |
+| Constructor mapping (Feature 5) | Guard applies to string→enum ctor parameter conversions, including when constructors are auto-selected via `ConstructorPreference.Auto` |
+
+### Diagnostics
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| **FM0046** | Info | Property '{0}' null/empty string coerced to `default({1})` instead of throwing (disabled by default; enable via `.editorconfig`) |
+
+### Behavioral Contract
+
+| Scenario | v1.5 Behavior | v1.6 Behavior |
+|----------|---------------|---------------|
+| `null` string → enum (Parse) | `ArgumentNullException` | `default(TEnum)` |
+| `""` string → enum (Parse) | `ArgumentException` | `default(TEnum)` |
+| `null` string → enum (TryParse) | `default(TEnum)` (TryParse returns false) | `default(TEnum)` (explicit guard) |
+| `""` string → enum (TryParse) | Parses to `(TEnum)0` silently | `default(TEnum)` (explicit guard) |
+| Valid string → enum | `Enum.Parse` / `TryParse` as before | Unchanged |
+| `null` string → nullable enum | Follows `NullPropertyHandling` | `(TEnum?)null` |
+| `""` string → nullable enum | `ArgumentException` (Parse) | `(TEnum?)null` |
+
+### Migration Notes
+
+This is a **behavioral change** from v1.5. Projects that relied on `Enum.Parse` throwing on null/empty strings to detect data errors will now silently get `default(TEnum)`. If throw-on-null is desired, use `NullPropertyHandling.ThrowException` for the null case; for empty strings, use a `[ForgeFrom]` resolver.
+
+### Competitor Comparison
+
+| Aspect | AutoMapper | Mapperly | ForgeMap v1.6 |
+|--------|-----------|---------|---------------|
+| Null string → enum | `default(T)` | `Enum.Parse` (throws) | `default(T)` |
+| Empty string → enum | `default(T)` | `Enum.Parse` (throws) | `default(T)` |
+| Configuration | None (always default) | None | `StringToEnum` mode + `NullPropertyHandling` |
+
+---
+
+## Feature 2: Nullable-Safe Collection Coercion
+
+> **Issue:** [#110](https://github.com/superyyrrzz/ForgeMap/issues/110)
+
+### Problem
+
+ForgeMap v1.5 added collection type coercion (e.g., `IDictionary<K,V>` → `IReadOnlyDictionary<K,V>`). However, when the element type's nullability differs between source and destination, the generated assignment triggers **CS8620** (nullable reference type variance), which fails under `TreatWarningsAsErrors`.
+
+This is extremely common when mapping between legacy API models (pre-nullable annotations) and modern domain models:
+
+```csharp
+// Source (AutoRest-generated, no nullable annotations):
+public IDictionary<string, object> Metadata { get; set; }
+
+// Destination (modern C# with nullable annotations):
+public IReadOnlyDictionary<string, object?> Metadata { get; init; }
+
+// v1.5 generates:
+dest.Metadata = source.Metadata;  // CS8620: nullability mismatch (object vs object?)
+```
+
+### Design
+
+When the generator detects a collection or dictionary coercion where element types differ only in nullability annotation (e.g., `object` vs `object?`, `string` vs `string?`), it applies a nullable-safe cast or adapter instead of a direct assignment.
+
+The detection is based on comparing element types after stripping nullable annotations (`WithNullableAnnotation(NullableAnnotation.None)`). If the underlying types match but annotations differ, nullable-safe coercion is applied.
+
+### Generated Code
+
+**Dictionary value nullability widening** (`object` → `object?`):
+
+```csharp
+// IDictionary<string, object> → IReadOnlyDictionary<string, object?>
+// Widening: non-nullable → nullable is inherently safe, but C# nullable analysis
+// treats generic type parameters as invariant, so an explicit conversion is needed.
+
+// Strategy: use type-test + fallback materialization
+dest.Metadata = source.Metadata is IReadOnlyDictionary<string, object?> __cast_Metadata
+    ? __cast_Metadata
+    : source.Metadata?.ToDictionary(
+        __kv => __kv.Key,
+        __kv => (object?)__kv.Value);
+```
+
+**Dictionary value nullability narrowing** (`object?` → `object`):
+
+```csharp
+// IReadOnlyDictionary<string, object?> → IDictionary<string, object>
+// Narrowing: nullable → non-nullable requires filtering or asserting.
+// Use NullForgiving (!) since the user explicitly declared the destination as non-nullable.
+dest.Metadata = source.Metadata?.ToDictionary(
+    __kv => __kv.Key,
+    __kv => __kv.Value!);
+```
+
+**List/sequence element nullability widening** (`T` → `T?`):
+
+```csharp
+// List<string> → IReadOnlyList<string?>
+// Widening: safe, but generic variance requires explicit conversion
+dest.Items = source.Items is IReadOnlyList<string?> __cast_Items
+    ? __cast_Items
+    : source.Items?.Select(__item => (string?)__item).ToList();
+```
+
+**List/sequence element nullability narrowing** (`T?` → `T`):
+
+```csharp
+// IReadOnlyList<string?> → List<string>
+// Narrowing: use NullForgiving
+dest.Items = source.Items?.Select(__item => __item!).ToList()
+    ?? null!;
+```
+
+**Combined collection type coercion + nullable element coercion:**
+
+When both the collection wrapper type AND element nullability differ, both conversions are composed:
+
+```csharp
+// IDictionary<string, object> → IReadOnlyDictionary<string, object?>
+// Collection type coercion (IDictionary → IReadOnlyDictionary) +
+// Element nullability widening (object → object?)
+dest.Metadata = source.Metadata is IReadOnlyDictionary<string, object?> __cast_Metadata
+    ? __cast_Metadata
+    : source.Metadata is Dictionary<string, object> __dict_Metadata
+        ? new global::System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(
+            new global::System.Collections.Generic.Dictionary<string, object?>(
+                __dict_Metadata.Select(__kv =>
+                    new global::System.Collections.Generic.KeyValuePair<string, object?>(
+                        __kv.Key, __kv.Value)),
+                __dict_Metadata.Comparer))
+        : new global::System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(
+            source.Metadata.ToDictionary(
+                __kv => __kv.Key,
+                __kv => (object?)__kv.Value));
+```
+
+### Null Handling
+
+Nullable-safe collection coercion respects `NullPropertyHandling` — the null-handling wrapper encloses the entire coercion expression, same as regular collection coercion in v1.5.
+
+### Interaction with Existing Features
+
+| Feature | Interaction |
+|---------|-------------|
+| Collection type coercion (v1.5) | This feature extends v1.5 coercion to handle element nullability differences. When both collection type AND element nullability differ, both conversions compose |
+| `NullPropertyHandling` | Applied at the outer level — same as v1.5 |
+| `[ConvertWith]` | Converter takes full precedence — nullable coercion not applied |
+| `[ForgeFrom]` | Resolver takes precedence |
+| `TreatWarningsAsErrors` | The fix specifically targets CS8620 compatibility |
+| Constructor mapping (Feature 5) | Nullable-safe coercion applies to collection-typed constructor parameters, same as property assignment |
+
+### Diagnostics
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| **FM0047** | Info | Property '{0}' element nullability coerced from '{1}' to '{2}' (disabled by default; enable via `.editorconfig`) |
+
+### Behavioral Contract
+
+| Scenario | v1.5 Behavior | v1.6 Behavior |
+|----------|---------------|---------------|
+| `IDictionary<K,V>` → `IReadOnlyDictionary<K,V?>` | `dest.X = source.X` (CS8620) | Nullable-safe cast/adapter |
+| `List<T?>` → `IReadOnlyList<T>` | `dest.X = source.X` (CS8620) | Select with `!` operator |
+| Same nullability, different collection type | v1.5 coercion (unchanged) | Unchanged |
+| Same nullability, same collection type | Direct assignment (unchanged) | Unchanged |
+
+### Competitor Comparison
+
+| Aspect | AutoMapper | Mapperly | ForgeMap v1.6 |
+|--------|-----------|---------|---------------|
+| Nullable element coercion | ✅ Runtime (implicit) | ❌ CS8620 in some cases | ✅ Compile-time safe |
+| Combined with type coercion | ✅ Runtime | ❌ | ✅ Composed conversions |
+| CS8620 safety | N/A (runtime) | Partial | ✅ Full |
+
+---
+
+## Feature 3: Per-Property `ConvertWith`
+
+> **Issue:** [#111](https://github.com/superyyrrzz/ForgeMap/issues/111)
+
+### Problem
+
+`[ConvertWith]` is currently method-level only (`AttributeTargets.Method`). When a mapping has 20+ properties but only 1-2 need custom conversion, the entire method must stay manual — losing all ForgeMap benefits for the other properties.
+
+```csharp
+// 19 out of 20 properties are same-name, same-type — perfect for ForgeMap
+// But 1 property (Type) needs StringEnum<T> → T conversion
+// So the entire method must be manual:
+private static DAO.User ForgeUser(Models.User source) => new()
+{
+    Login = source.Login,        // simple
+    Id = source.Id,              // simple
+    // ... 17 more simple properties ...
+    Type = GetStringEnumValue<Models.UserType, UserType>(source.Type),  // needs converter
+    SiteAdmin = source.SiteAdmin, // simple
+};
+```
+
+### Design
+
+Add a `ConvertWith` named property to `[ForgeProperty]`. When set, the generator calls the specified method to convert that single property, while all other properties are auto-mapped as usual. The converter method must accept the source property value and return the destination property type.
+
+### API Surface
+
+```csharp
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+public sealed class ForgePropertyAttribute : Attribute
+{
+    // ... existing constructor and properties ...
+
+    /// <summary>
+    /// The name of a method on the forger class to call for converting this property's value.
+    /// The method must accept the source property type and return the destination property type.
+    /// Use nameof() for compile-time safety.
+    /// When set, the generator calls this method instead of direct assignment for this property.
+    /// This is distinct from the method-level [ConvertWith] which takes over the entire method body.
+    /// </summary>
+    public string? ConvertWith { get; set; }
+}
+```
+
+### Usage
+
+```csharp
+[ForgeMap]
+public partial class AppForger
+{
+    // Only the Type property needs custom conversion — all others auto-map
+    [ForgeProperty(nameof(Models.User.Type), nameof(DAO.User.Type),
+        ConvertWith = nameof(ConvertUserType))]
+    public partial DAO.User ForgeUser(Models.User source);
+
+    private static UserType ConvertUserType(StringEnum<UserType> source)
+        => source.Value;
+}
+```
+
+**Multiple per-property converters:**
+
+```csharp
+[ForgeProperty(nameof(Source.CreatedAt), nameof(Dest.CreatedAt),
+    ConvertWith = nameof(ToUtcDateTime))]
+[ForgeProperty(nameof(Source.UpdatedAt), nameof(Dest.UpdatedAt),
+    ConvertWith = nameof(ToUtcDateTime))]
+[ForgeProperty(nameof(Source.Type), nameof(Dest.Type),
+    ConvertWith = nameof(ConvertUserType))]
+public partial Dest ForgeModel(Source source);
+
+private static DateTime ToUtcDateTime(DateTimeOffset source) => source.UtcDateTime;
+private static UserType ConvertUserType(StringEnum<UserType> source) => source.Value;
+```
+
+**With `NullPropertyHandling`:**
+
+`ConvertWith` and `NullPropertyHandling` can be combined on the same `[ForgeProperty]`. The null check is applied before calling the converter:
+
+```csharp
+[ForgeProperty("ClosedAt", "ClosedAt",
+    ConvertWith = nameof(ToUtcDateTime),
+    NullPropertyHandling = NullPropertyHandling.SkipNull)]
+public partial Dest ForgeModel(Source source);
+```
+
+### Resolution Algorithm
+
+1. **Detect attribute**: Check if a `[ForgeProperty]` has `ConvertWith` set (non-null)
+2. **Resolve method**: Find a method on the forger class with the specified name. The method must:
+   - Accept exactly one parameter whose type is assignable from the source property type
+   - Return a type assignable to the destination property type
+   - Be accessible from the generated code (private, internal, or public — static or instance)
+3. **Generate call**: Emit `ConverterMethod(source.SourceProp)` as the assignment expression for the destination property
+4. **Null integration**: When `NullPropertyHandling` is also set, the null check wraps the converter call
+
+### Generated Code
+
+**Basic per-property conversion:**
+
+```csharp
+public partial DAO.User ForgeUser(Models.User source)
+{
+    if (source == null) return null!;
+
+    var __result = new DAO.User();
+
+    // Auto-mapped properties (19 of them)
+    __result.Login = source.Login;
+    __result.Id = source.Id;
+    // ... 17 more ...
+    __result.SiteAdmin = source.SiteAdmin;
+
+    // Per-property ConvertWith
+    __result.Type = ConvertUserType(source.Type);
+
+    return __result;
+}
+```
+
+**Nullable source property with ConvertWith:**
+
+```csharp
+// DateTimeOffset? ClosedAt → DateTime? ClosedAt
+// ConvertWith + nullable source → null-conditional call
+__result.ClosedAt = source.ClosedAt is { } __v_ClosedAt
+    ? ToUtcDateTime(__v_ClosedAt)
+    : null;
+```
+
+**Non-nullable source → non-nullable dest (simple):**
+
+```csharp
+// DateTimeOffset CreatedAt → DateTime CreatedAt
+__result.CreatedAt = ToUtcDateTime(source.CreatedAt);
+```
+
+**With NullPropertyHandling.SkipNull:**
+
+```csharp
+// DateTimeOffset? ClosedAt → DateTime ClosedAt (non-nullable dest, SkipNull)
+if (source.ClosedAt is { } __v_ClosedAt)
+    __result.ClosedAt = ToUtcDateTime(__v_ClosedAt);
+```
+
+**With NullPropertyHandling.CoalesceToDefault:**
+
+```csharp
+// DateTimeOffset? ClosedAt → DateTime ClosedAt (non-nullable dest, CoalesceToDefault)
+__result.ClosedAt = source.ClosedAt is { } __v_ClosedAt
+    ? ToUtcDateTime(__v_ClosedAt)
+    : default(DateTime);
+```
+
+**init/required properties:**
+
+Per-property `ConvertWith` works with `init` and `required` properties — the converter call is placed in the object initializer:
+
+```csharp
+var __result = new Dest
+{
+    // init/required with ConvertWith
+    CreatedAt = ToUtcDateTime(source.CreatedAt),
+    Type = ConvertUserType(source.Type),
+};
+```
+
+**Constructor parameters:**
+
+When a destination type uses constructor-based mapping (Feature 5) and a constructor parameter corresponds to a `[ForgeProperty(ConvertWith = ...)]`, the converter is called in the constructor argument:
+
+```csharp
+var __result = new Dest(
+    createdAt: ToUtcDateTime(source.CreatedAt),
+    type: ConvertUserType(source.Type)
+);
+```
+
+### Interaction with Existing Features
+
+| Feature | Interaction |
+|---------|-------------|
+| Method-level `[ConvertWith]` | Separate concern — method-level takes over the entire method body; per-property applies to one property only. Both can exist on the same forger class but not in ways that conflict (method-level makes per-property irrelevant for that method) |
+| `[ForgeFrom]` | `[ForgeFrom]` receives the entire source object; per-property `ConvertWith` receives only the source property value. If both target the same destination property, emit **FM0048** |
+| `[ForgeWith]` | `[ForgeWith]` calls another forge method; per-property `ConvertWith` calls a converter. If both target the same destination property, emit **FM0048** |
+| `[Ignore]` | If a property is both ignored and has `ConvertWith`, the ignore takes precedence (the property is skipped) |
+| `NullPropertyHandling` | Per-property override on `[ForgeProperty]` applies to the null-handling wrapper around the converter call |
+| `[ReverseForge]` | Reverse method does NOT auto-apply the per-property `ConvertWith` — there is no general way to reverse an arbitrary converter. Use explicit `[ForgeProperty(ConvertWith = ...)]` on the reverse method if needed |
+| Auto-wiring | `ConvertWith` takes precedence over auto-wired forge methods for the specified property |
+| `[AfterForge]` | `ConvertWith` assignment executes before the `[AfterForge]` callback — the callback can override the converted value |
+| `ExistingTarget` / `CollectionUpdate` | `ConvertWith` and `ExistingTarget` can coexist on the same `[ForgeProperty]` — the converter produces the value, then `ExistingTarget` logic applies to how it's assigned |
+
+### Diagnostics
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| **FM0048** | Error | Per-property `ConvertWith` method '{0}' not found on forger class, or has wrong signature. Expected: `{1} {0}({2})` — method must accept the source property type and return the destination property type |
+| **FM0049** | Error | Property '{0}' has conflicting conversion attributes: `ConvertWith` on `[ForgeProperty]` cannot be combined with `[ForgeFrom]` or `[ForgeWith]` targeting the same destination property |
+
+### Behavioral Contract
+
+| Scenario | Behavior |
+|----------|----------|
+| Valid converter method | Converter called for that property; all others auto-mapped |
+| Method not found or wrong signature | FM0048 error |
+| Conflicts with `[ForgeFrom]` or `[ForgeWith]` | FM0049 error |
+| Nullable source, nullable dest | Null-conditional converter call |
+| Nullable source, non-nullable dest | `NullPropertyHandling` governs null case; converter called for non-null |
+| Converter throws | Exception propagates — no wrapping |
+| `init`/`required` destination | Converter call placed in object initializer |
+| Constructor parameter destination | Converter call placed in constructor argument |
+
+### Competitor Comparison
+
+| Aspect | AutoMapper | Mapperly | ForgeMap v1.6 |
+|--------|-----------|---------|---------------|
+| Per-property conversion | ✅ `.ConvertUsing()` per member | ✅ `MapProperty` with user method | ✅ `[ForgeProperty(ConvertWith = ...)]` |
+| Compile-time validation | ❌ Runtime errors | ✅ Compile-time | ✅ FM0048 diagnostic |
+| Combined with null handling | Runtime config | Limited | ✅ `NullPropertyHandling` on same attribute |
+| Scoped to single property | ✅ | ✅ | ✅ |
+
+---
+
+## Feature 4: Built-In Type Coercions
+
+> **Issue:** [#112](https://github.com/superyyrrzz/ForgeMap/issues/112)
+
+### Problem
+
+Two common type mismatches still require manual methods despite ForgeMap's auto-mapping capabilities:
+
+**1. `DateTimeOffset → DateTime`**: Many APIs (Octokit.Webhooks, ASP.NET Core) use `DateTimeOffset`, while domain/DAO models use `DateTime`. The standard lossless conversion is `.UtcDateTime`.
+
+**2. Generic wrapper unwrapping (e.g., `StringEnum<T> → T`)**: Libraries like Octokit.Webhooks wrap enums in `StringEnum<T>` for JSON flexibility. The underlying value is accessible via `.Value`.
+
+```csharp
+// Must be manual because of these type mismatches:
+private static DAO.Milestone ForgeMilestone(Models.Milestone source) => new()
+{
+    // ... 12 simple properties ...
+    CreatedAt = source.CreatedAt.UtcDateTime,   // DateTimeOffset → DateTime
+    UpdatedAt = source.UpdatedAt.UtcDateTime,   // DateTimeOffset → DateTime
+    Type = source.Type.Value,                    // StringEnum<T> → T
+};
+```
+
+### Design
+
+The generator recognizes specific type pairs and emits appropriate conversion expressions automatically. This is a compile-time extension of the existing type coercion system (string↔enum, compatible enums) — no new attributes or configuration required.
+
+### Built-In Coercions
+
+#### 4a. `DateTimeOffset → DateTime`
+
+The generator detects when the source property type is `System.DateTimeOffset` and the destination property type is `System.DateTime`, and emits `.UtcDateTime`:
+
+```csharp
+// DateTimeOffset → DateTime
+__result.CreatedAt = source.CreatedAt.UtcDateTime;
+
+// DateTimeOffset? → DateTime?
+__result.ClosedAt = source.ClosedAt?.UtcDateTime;
+
+// DateTimeOffset? → DateTime (non-nullable dest, NullPropertyHandling applies)
+// NullForgiving (default):
+__result.ClosedAt = source.ClosedAt?.UtcDateTime ?? default!;
+// CoalesceToDefault:
+__result.ClosedAt = source.ClosedAt?.UtcDateTime ?? default(DateTime);
+// ThrowException:
+__result.ClosedAt = source.ClosedAt?.UtcDateTime
+    ?? throw new global::System.ArgumentNullException("source.ClosedAt");
+```
+
+The reverse direction (`DateTime → DateTimeOffset`) is also supported via the implicit conversion (`new DateTimeOffset(dateTime)`):
+
+```csharp
+// DateTime → DateTimeOffset (implicit conversion exists in .NET)
+__result.CreatedAt = source.CreatedAt;  // implicit operator handles this
+
+// DateTime? → DateTimeOffset?
+__result.ClosedAt = source.ClosedAt.HasValue
+    ? new global::System.DateTimeOffset(source.ClosedAt.Value)
+    : (global::System.DateTimeOffset?)null;
+```
+
+#### 4b. Generic Wrapper Unwrapping (`Wrapper<T> → T`)
+
+The generator detects when:
+1. The source property type is a generic type `W<T>` (any single-type-parameter generic)
+2. The destination property type is `T` (the generic type argument)
+3. `W<T>` has a public property named `Value` of type `T`
+
+When all conditions are met, the generator emits `.Value`:
+
+```csharp
+// StringEnum<UserType> → UserType
+__result.Type = source.Type.Value;
+
+// StringEnum<UserType>? → UserType? (nullable wrapper)
+__result.Type = source.Type?.Value;
+
+// StringEnum<UserType>? → UserType (non-nullable dest, NullPropertyHandling applies)
+// NullForgiving:
+__result.Type = source.Type?.Value ?? default!;
+// CoalesceToDefault:
+__result.Type = source.Type?.Value ?? default(UserType);
+```
+
+**Matching criteria for generic wrapper detection:**
+
+1. Source type must be a named type with exactly one type argument: `W<T>`
+2. Source type must have a public, non-static property named `Value`
+3. The `Value` property's return type must match the destination property type (or be assignable after stripping nullable annotations)
+4. The destination type must be `T` (the type argument of `W<T>`)
+5. Not triggered when the destination type is `W<T>` (same wrapper type — that's a direct assignment)
+
+This is intentionally narrow to avoid false positives. The `Value` property name is a well-established convention (`Nullable<T>.Value`, `StronglyTypedId<T>.Value`, `StringEnum<T>.Value`).
+
+### Precedence
+
+Built-in type coercions slot into the existing property assignment priority:
+
+1. Explicit `[ForgeProperty]` / `[ForgeFrom]` / `[Ignore]` / `[ForgeWith]`
+2. Per-property `ConvertWith` (Feature 3)
+3. Direct name match with compatible types (existing)
+4. Compatible enum casting (existing)
+5. String↔enum auto-conversion (existing)
+6. **Built-in type coercions (new — DateTimeOffset→DateTime, wrapper unwrap)**
+7. Auto-wire inline collections (existing)
+8. Auto-wire forge methods (existing)
+9. Unmapped → FM0006
+
+### Interaction with Existing Features
+
+| Feature | Interaction |
+|---------|-------------|
+| `[ForgeProperty(ConvertWith = ...)]` | `ConvertWith` takes precedence — built-in coercion skipped |
+| `[ForgeFrom]` | Resolver takes precedence |
+| `NullPropertyHandling` | Applies to the coerced expression (same as other auto-conversions) |
+| `[ReverseForge]` | Reverse direction uses the inverse coercion when available (DateTime→DateTimeOffset via implicit conversion, `T → Wrapper<T>` not auto-reversed — use explicit `[ForgeProperty]`) |
+| Constructor mapping | Coercions apply to constructor parameter matching (same as string→enum) |
+| Auto-wiring | Built-in coercion runs before auto-wire — if a `DateTimeOffset→DateTime` match exists, it does not trigger auto-wire attempts |
+
+### Diagnostics
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| **FM0050** | Info | Property '{0}' auto-coerced from '{1}' to '{2}' via {3} (disabled by default; enable via `.editorconfig`) |
+
+### Behavioral Contract
+
+| Scenario | Behavior |
+|----------|----------|
+| `DateTimeOffset` → `DateTime` | `.UtcDateTime` |
+| `DateTimeOffset?` → `DateTime?` | `?.UtcDateTime` |
+| `DateTime` → `DateTimeOffset` | Direct assignment (implicit conversion) |
+| `Wrapper<T>` → `T` (with `.Value` property) | `.Value` |
+| `Wrapper<T>?` → `T?` | `?.Value` |
+| `T` → `Wrapper<T>` | Not auto-reversed — use `[ForgeProperty(ConvertWith = ...)]` |
+| No `.Value` property on wrapper type | No coercion — falls through to auto-wire |
+
+### Competitor Comparison
+
+| Aspect | AutoMapper | Mapperly | ForgeMap v1.6 |
+|--------|-----------|---------|---------------|
+| `DateTimeOffset→DateTime` | ✅ Runtime conversion | ❌ Manual `MapProperty` | ✅ Built-in `.UtcDateTime` |
+| Generic wrapper unwrap | ❌ Manual `ConvertUsing` | ❌ Manual | ✅ Built-in `.Value` detection |
+| Compile-time | ❌ Runtime | ✅ | ✅ |
+| Reversible | ✅ Runtime | ❌ | ✅ `DateTime→DateTimeOffset` only |
+
+---
+
+## Feature 5: Constructor Preference for Get-Only Destination Types
+
+> **Issue:** [#108](https://github.com/superyyrrzz/ForgeMap/issues/108)
+
+### Problem
+
+ForgeMap currently maps only to settable properties. When a destination type has a parameterized constructor with get-only properties, ForgeMap *does* resolve the constructor and match parameters — but **only when no parameterless constructor exists**. If a parameterless constructor is available, the generator always prefers it (using object initializer), which leaves get-only properties unmapped.
+
+Many domain models enforce immutability with get-only properties set exclusively through the constructor:
+
+```csharp
+public class FileViewObjectOutput
+{
+    public FileViewObjectOutput(string fileId, string locale, FileType type, string version,
+                                IReadOnlyDictionary<string, object?>? metadata = null)
+    {
+        FileId = fileId;
+        Locale = locale;
+        Type = type;
+        Version = version;
+        Metadata = metadata;
+    }
+
+    public string FileId { get; }     // get-only — can only be set via ctor
+    public string Locale { get; }     // get-only
+    public FileType Type { get; }     // get-only
+    public string Version { get; }    // get-only
+    public IReadOnlyDictionary<string, object?>? Metadata { get; }  // get-only
+}
+```
+
+### Design
+
+The generator applies **automatic constructor preference** when it detects that the destination type has properties that can only be set via constructor. Specifically:
+
+1. **Scan destination properties**: For each property on the destination type, classify as:
+   - **Settable**: has a public setter (`set` or `init`)
+   - **Get-only**: has only a public getter — can only be set via constructor
+
+2. **Decision rule**: If the destination type has **any get-only properties with matching source properties**, prefer the parameterized constructor over the parameterless one — even when a parameterless constructor exists. The rationale: a parameterless constructor would leave get-only properties at their default values, which is almost never the user's intent when source properties with matching names exist.
+
+3. **Hybrid mapping**: After constructor invocation, remaining settable/init properties that were NOT covered by constructor parameters are mapped via object initializer or post-construction assignment (existing behavior).
+
+This is a refinement of the existing `ResolveConstructor()` logic, which already scores constructors by parameter coverage. The change is in the preference decision: instead of always preferring the parameterless constructor, the generator now evaluates whether skipping it would allow more properties to be mapped.
+
+### Configuration
+
+Constructor preference is controlled by a new `ConstructorPreference` property on `[ForgeMap]` and `[ForgeMapDefaults]`:
+
+```csharp
+/// <summary>
+/// Controls how the generator selects constructors for destination type instantiation.
+/// </summary>
+public enum ConstructorPreference
+{
+    /// <summary>
+    /// The generator automatically detects when a parameterized constructor is needed
+    /// to map get-only properties. If all destination properties are settable, the
+    /// parameterless constructor is preferred. If any get-only properties have matching
+    /// source properties, the best-matching parameterized constructor is selected.
+    /// Default behavior.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Always prefer the parameterless constructor when available (v1.5 behavior).
+    /// Get-only properties remain unmapped.
+    /// </summary>
+    PreferParameterless
+}
+```
+
+```csharp
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class ForgeMapAttribute : Attribute
+{
+    // ... existing properties ...
+
+    /// <summary>
+    /// Controls constructor selection for destination types.
+    /// Default is <see cref="ConstructorPreference.Auto"/>.
+    /// </summary>
+    public ConstructorPreference ConstructorPreference { get; set; } = ConstructorPreference.Auto;
+}
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+public sealed class ForgeMapDefaultsAttribute : Attribute
+{
+    // ... existing properties ...
+
+    /// <summary>
+    /// Assembly-level default for constructor preference. Default is Auto.
+    /// </summary>
+    public ConstructorPreference ConstructorPreference { get; set; } = ConstructorPreference.Auto;
+}
+```
+
+### Constructor Selection Algorithm (Updated)
+
+The existing `ResolveConstructor()` method is updated with an additional step:
+
+1. **Enumerate constructors**: Get all public instance constructors
+2. **Check for parameterless constructor**: If one exists:
+   - **(New)** If `ConstructorPreference == Auto`: scan destination properties for get-only members with matching source properties. If any are found, proceed to step 3 (do not return early)
+   - If `ConstructorPreference == PreferParameterless`: return `(null, null)` — use parameterless ctor (v1.5 behavior)
+3. **Score parameterized constructors**: For each constructor, count how many parameters can be satisfied from source properties (existing logic — case-insensitive, supports `[ForgeProperty]` remapping, enum compatibility, string→enum, auto-wire)
+4. **Select best constructor**:
+   - If the best constructor covers ALL get-only properties that have matching source properties, select it
+   - If multiple constructors tie on score, emit **FM0013** (existing ambiguous diagnostic)
+   - If no constructor can cover the get-only properties, emit **FM0052** (new: constructor cannot satisfy get-only properties)
+5. **Hybrid mapping**: Properties covered by constructor parameters are excluded from object initializer / post-construction assignment. Remaining settable/init properties are mapped as usual.
+
+### Usage
+
+```csharp
+[ForgeMap]  // ConstructorPreference defaults to Auto
+public partial class AppForger
+{
+    // FileViewObjectOutput has get-only properties → constructor auto-selected
+    public partial FileViewObjectOutput Forge(FileViewObjectInput source);
+
+    // OrderDto has all settable properties → parameterless ctor used (unchanged)
+    public partial OrderDto Forge(Order source);
+}
+
+// Opt out to v1.5 behavior:
+[ForgeMap(ConstructorPreference = ConstructorPreference.PreferParameterless)]
+public partial class LegacyForger
+{
+    public partial FileViewObjectOutput Forge(FileViewObjectInput source);
+}
+```
+
+### Generated Code
+
+**Get-only destination type (constructor preferred):**
+
+```csharp
+public partial FileViewObjectOutput Forge(FileViewObjectInput source)
+{
+    if (source == null) return null!;
+
+    var __result = new FileViewObjectOutput(
+        fileId: source.FileId,
+        locale: source.Locale,
+        type: source.Type,                // direct match
+        version: source.Version,
+        metadata: source.Metadata          // type coercion may apply (Feature 2/4)
+    );
+
+    // No post-construction assignments — all properties are get-only and covered by ctor
+
+    return __result;
+}
+```
+
+**Hybrid (constructor + settable properties):**
+
+```csharp
+public class HybridOutput
+{
+    public HybridOutput(string id, string name)
+    {
+        Id = id;
+        Name = name;
+    }
+
+    public string Id { get; }         // get-only → ctor
+    public string Name { get; }       // get-only → ctor
+    public string? Description { get; set; }  // settable → post-construction
+    public int Count { get; set; }    // settable → post-construction
+}
+
+// Generated:
+public partial HybridOutput Forge(HybridInput source)
+{
+    if (source == null) return null!;
+
+    var __result = new HybridOutput(
+        id: source.Id,
+        name: source.Name
+    );
+
+    __result.Description = source.Description;
+    __result.Count = source.Count;
+
+    return __result;
+}
+```
+
+**Constructor with optional parameters and defaults:**
+
+```csharp
+public class OutputWithDefaults
+{
+    public OutputWithDefaults(string id, GroupType groupType = GroupType.None,
+                              IReadOnlyDictionary<string, object?>? metadata = null)
+    { /* ... */ }
+
+    public string Id { get; }
+    public GroupType GroupType { get; }
+    public IReadOnlyDictionary<string, object?>? Metadata { get; }
+}
+
+// Generated — optional parameters with no matching source property use their defaults:
+public partial OutputWithDefaults Forge(Input source)
+{
+    if (source == null) return null!;
+
+    var __result = new OutputWithDefaults(
+        id: source.Id
+        // groupType and metadata omitted — use constructor defaults
+    );
+
+    return __result;
+}
+```
+
+If the source *does* have matching properties for optional parameters, they are included:
+
+```csharp
+var __result = new OutputWithDefaults(
+    id: source.Id,
+    groupType: source.GroupType,
+    metadata: source.Metadata
+);
+```
+
+**With `[ForgeProperty]` remapping to constructor parameters:**
+
+`[ForgeProperty]` mappings are used to match source properties to constructor parameter names:
+
+```csharp
+[ForgeProperty(nameof(Source.BuildId), nameof(Dest.Id))]
+public partial Dest Forge(Source source);
+
+// Constructor parameter "id" matches destination property "Id" via [ForgeProperty]:
+var __result = new Dest(
+    id: source.BuildId  // remapped via [ForgeProperty]
+);
+```
+
+**With per-property `ConvertWith` (Feature 3) on constructor parameters:**
+
+```csharp
+[ForgeProperty(nameof(Source.CreatedAt), nameof(Dest.CreatedAt),
+    ConvertWith = nameof(ToUtcDateTime))]
+public partial Dest Forge(Source source);
+
+// Generated:
+var __result = new Dest(
+    createdAt: ToUtcDateTime(source.CreatedAt)  // ConvertWith applied to ctor arg
+);
+```
+
+**With built-in type coercions (Feature 4) on constructor parameters:**
+
+```csharp
+// Source.CreatedAt is DateTimeOffset, Dest constructor expects DateTime
+var __result = new Dest(
+    createdAt: source.CreatedAt.UtcDateTime  // built-in coercion
+);
+```
+
+### Interaction with Existing Features
+
+| Feature | Interaction |
+|---------|-------------|
+| Existing constructor resolution | This feature modifies the *preference* decision only. The scoring and matching logic remains the same |
+| `[ForgeProperty]` | Property remapping is used for constructor parameter matching (existing behavior, unchanged) |
+| `[ForgeFrom]` | Resolver-mapped properties are excluded from constructor parameter matching. They are applied post-construction |
+| `[ForgeWith]` | ForgeWith-mapped properties are excluded from constructor matching. Applied post-construction |
+| Per-property `ConvertWith` (Feature 3) | Converter call is placed in constructor argument expression |
+| Built-in type coercions (Feature 4) | Coercion expressions applied to constructor parameter values |
+| String→enum (v1.4) | Already supported in constructor parameter matching, unchanged |
+| `NullPropertyHandling` | Applied to constructor argument expressions for nullable source → non-nullable parameter |
+| `NullHandling` | Source null check still applied before constructor call |
+| `[AfterForge]` | Callback invoked after construction and post-construction assignments |
+| `init`/`required` properties | `init` properties not covered by the constructor are mapped via object initializer (existing behavior) |
+| `ExistingTarget = true` | Not applicable — constructor mapping creates new instances, `ExistingTarget` mutates existing ones |
+| `[ReverseForge]` | Reverse method independently resolves constructor for its destination type |
+| FM0004 (no accessible constructor) | Still emitted when no constructor can satisfy the destination type |
+| FM0013 (ambiguous constructor) | Still emitted when multiple constructors tie on parameter coverage score |
+| FM0014 (constructor parameter no matching source) | Still emitted for required parameters with no source match |
+
+### Diagnostics
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| **FM0051** | Info | Constructor preferred over parameterless for type '{0}': {1} get-only properties matched (disabled by default; enable via `.editorconfig`) |
+| **FM0052** | Error | Constructor for type '{0}' cannot satisfy get-only properties: {1}. Consider adding `[ForgeProperty]` mappings or using `ConstructorPreference.PreferParameterless` |
+
+### Behavioral Contract
+
+| Scenario | v1.5 Behavior | v1.6 Behavior (Auto) |
+|----------|---------------|---------------------|
+| All properties settable, parameterless ctor exists | Parameterless ctor | Parameterless ctor (unchanged) |
+| Get-only properties, parameterless ctor exists | Parameterless ctor (get-only properties unmapped) | Best parameterized ctor selected |
+| Get-only properties, no parameterless ctor | Best parameterized ctor | Best parameterized ctor (unchanged) |
+| No constructor matches get-only properties | FM0004 | FM0052 (more specific error) |
+| Optional ctor parameters, no matching source | Omitted (use default) | Omitted (use default) — unchanged |
+| `ConstructorPreference.PreferParameterless` | N/A | v1.5 behavior restored |
+
+### Migration Notes
+
+This is a **behavioral change** from v1.5 for destination types with get-only properties and a parameterless constructor. In v1.5, the parameterless constructor was always preferred, leaving get-only properties unmapped (FM0006 warning). In v1.6, the generator now attempts to use a parameterized constructor to map those properties.
+
+If this causes issues (e.g., a constructor has side effects), use `ConstructorPreference = ConstructorPreference.PreferParameterless` to restore v1.5 behavior.
+
+### Competitor Comparison
+
+| Aspect | AutoMapper | Mapperly | ForgeMap v1.6 |
+|--------|-----------|---------|---------------|
+| Constructor mapping | ✅ Runtime reflection | ✅ Compile-time | ✅ Compile-time with auto-preference |
+| Get-only property detection | ✅ Automatic | ✅ Automatic | ✅ Automatic |
+| Constructor preference config | `.DisableCtorValidation()` | `MapperConstructor` attribute | `ConstructorPreference` enum |
+| Hybrid (ctor + setter) | ✅ | ✅ | ✅ |
+| Optional parameter handling | Skipped | Skipped | Omitted (uses ctor defaults) |
+| Compile-time validation | ❌ Runtime errors | ✅ | ✅ FM0013/FM0014/FM0052 |
+
+---
+
+## Diagnostics Summary
+
+| Code | Severity | Category | Feature | Description |
+|------|----------|----------|---------|-------------|
+| FM0046 | Info | `ForgeMap` | String→enum guard | Property '{0}' null/empty string coerced to `default({1})` |
+| FM0047 | Info | `ForgeMap` | Nullable collection coercion | Property '{0}' element nullability coerced from '{1}' to '{2}' |
+| FM0048 | Error | `ForgeMap` | Per-property `ConvertWith` | Per-property `ConvertWith` method '{0}' not found or wrong signature |
+| FM0049 | Error | `ForgeMap` | Per-property `ConvertWith` | Property '{0}' has conflicting conversion attributes |
+| FM0050 | Info | `ForgeMap` | Built-in type coercions | Property '{0}' auto-coerced from '{1}' to '{2}' via {3} |
+| FM0051 | Info | `ForgeMap` | Constructor preference | Constructor preferred over parameterless for type '{0}' |
+| FM0052 | Error | `ForgeMap` | Constructor preference | Constructor for type '{0}' cannot satisfy get-only properties: {1} |
+
+---
+
+## API Changes Summary
+
+### New Enum (v1.6)
+
+| Enum | Values | Description |
+|------|--------|-------------|
+| `ConstructorPreference` | `Auto`, `PreferParameterless` | Controls constructor selection strategy |
+
+### Modified Attributes (v1.6)
+
+| Attribute | Change | Description |
+|-----------|--------|-------------|
+| `ForgePropertyAttribute` | New property: `ConvertWith` (`string?`) | Per-property converter method name |
+| `ForgeMapAttribute` | New property: `ConstructorPreference` | Constructor selection strategy |
+| `ForgeMapDefaultsAttribute` | New property: `ConstructorPreference` | Assembly-level constructor selection default |
+
+### No New Attributes
+
+All v1.6 features work within the existing attribute surface (one new property on `ForgePropertyAttribute`, one new enum, two new config properties).
+
+---
+
+## Migration Guide
+
+### From v1.5 to v1.6
+
+v1.6 introduces two behavioral changes that may affect existing forgers:
+
+1. **String→enum null/empty handling (Feature 1)** — `Enum.Parse` on null/empty strings now returns `default(TEnum)` instead of throwing. This is safer but may change behavior for projects that relied on the exception. For projects using `StringToEnum.TryParse`, empty strings (`""`) now return `default(TEnum)` instead of being silently parsed to `(TEnum)0` — this is more consistent but may change behavior if your enums have meaningful zero values. **To preserve v1.5 behavior**: use `[ForgeFrom]` with an explicit resolver that calls `Enum.Parse` without the guard.
+
+2. **Constructor preference for get-only types (Feature 5)** — The generator now prefers parameterized constructors when the destination type has get-only properties with matching source properties. This may activate constructor-based mapping for types that previously used the parameterless constructor. **To preserve v1.5 behavior**: set `ConstructorPreference = ConstructorPreference.PreferParameterless` on the forger or assembly.
+
+3. **Nullable collection coercion (Feature 2)** — Properties that previously triggered CS8620 will now generate nullable-safe coercion code. This should only eliminate warnings, not change runtime behavior.
+
+4. **Per-property ConvertWith (Feature 3)** and **Built-in type coercions (Feature 4)** are opt-in — no behavior change unless explicitly used.
+
+---
+
+## Limitations
+
+| Limitation | Reason | Workaround |
+|-----------|--------|------------|
+| Built-in type coercions are not user-extensible | Hard-coded to avoid combinatorial complexity; per-property `ConvertWith` covers custom cases | Use `[ForgeProperty(ConvertWith = ...)]` for any coercion not built in |
+| Generic wrapper unwrap only matches `.Value` property | Narrow detection to avoid false positives | Use `[ForgeProperty(ConvertWith = ...)]` for wrappers with different accessor names |
+| Reverse direction not supported for `T → Wrapper<T>` | No general way to construct a wrapper from its inner value | Use explicit `[ForgeProperty(ConvertWith = ...)]` on the reverse method |
+| Constructor preference may select unexpected constructor | Auto-detection is based on get-only property coverage heuristic | Use `ConstructorPreference.PreferParameterless` to opt out |
+| String→enum empty-string guard always uses `default(TEnum)` | No configuration for custom empty-string behavior | Use `[ForgeFrom]` resolver for custom empty-string logic |
+
+---
+
+*Specification Version: 1.6 (2026-04-09)*
+*Status: Planned*
+*Deferred features: [SPEC-future-advanced-mapping.md](SPEC-future-advanced-mapping.md)*
+*License: MIT*

--- a/docs/SPEC-v1.6-migration-features.md
+++ b/docs/SPEC-v1.6-migration-features.md
@@ -142,7 +142,7 @@ var __result = new Dest(
 | `null` string → enum (TryParse) | `default(TEnum)` (TryParse returns false) | `default(TEnum)` (explicit guard) |
 | `""` string → enum (TryParse) | `default(TEnum)` (TryParse returns false) | `default(TEnum)` (explicit guard for consistency) |
 | Valid string → enum | `Enum.Parse` / `TryParse` as before | Unchanged |
-| `null` string → nullable enum | Follows `NullPropertyHandling` | `(TEnum?)null` |
+| `null` string → nullable enum | `(TEnum?)null` | `(TEnum?)null` |
 | `""` string → nullable enum | `ArgumentException` (Parse) | `(TEnum?)null` |
 
 ### Migration Notes
@@ -480,8 +480,8 @@ var __result = new Dest(
 | Feature | Interaction |
 |---------|-------------|
 | Method-level `[ConvertWith]` | Separate concern — method-level takes over the entire method body; per-property applies to one property only. Both can exist on the same forger class but not in ways that conflict (method-level makes per-property irrelevant for that method) |
-| `[ForgeFrom]` | `[ForgeFrom]` receives the entire source object; per-property `ConvertWith` receives only the source property value. If both target the same destination property, emit **FM0048** |
-| `[ForgeWith]` | `[ForgeWith]` calls another forge method; per-property `ConvertWith` calls a converter. If both target the same destination property, emit **FM0048** |
+| `[ForgeFrom]` | `[ForgeFrom]` receives the entire source object; per-property `ConvertWith` receives only the source property value. If both target the same destination property, emit **FM0049** |
+| `[ForgeWith]` | `[ForgeWith]` calls another forge method; per-property `ConvertWith` calls a converter. If both target the same destination property, emit **FM0049** |
 | `[Ignore]` | If a property is both ignored and has `ConvertWith`, the ignore takes precedence (the property is skipped) |
 | `NullPropertyHandling` | Per-property override on `[ForgeProperty]` applies to the null-handling wrapper around the converter call |
 | `[ReverseForge]` | Reverse method does NOT auto-apply the per-property `ConvertWith` — there is no general way to reverse an arbitrary converter. Use explicit `[ForgeProperty(ConvertWith = ...)]` on the reverse method if needed |

--- a/docs/SPEC-v1.6-migration-features.md
+++ b/docs/SPEC-v1.6-migration-features.md
@@ -188,19 +188,18 @@ The detection is based on comparing element types after stripping nullable annot
 
 ### Generated Code
 
-**Dictionary value nullability widening** (`object` → `object?`):
+**Dictionary value nullability widening** (`IDictionary<K,V>` → `IDictionary<K,V?>`):
 
 ```csharp
-// IDictionary<string, object> → IReadOnlyDictionary<string, object?>
+// IDictionary<string, object> → IDictionary<string, object?>
 // Widening: non-nullable → nullable is inherently safe, but C# nullable analysis
 // treats generic type parameters as invariant, so an explicit conversion is needed.
+// Note: same collection wrapper type — only element nullability differs.
 
-// Strategy: use type-test + fallback materialization
-dest.Metadata = source.Metadata is IReadOnlyDictionary<string, object?> __cast_Metadata
-    ? __cast_Metadata
-    : source.Metadata?.ToDictionary(
-        __kv => __kv.Key,
-        __kv => (object?)__kv.Value);
+// Strategy: materialize with widened value type
+dest.Metadata = source.Metadata?.ToDictionary(
+    __kv => __kv.Key,
+    __kv => (object?)__kv.Value);
 ```
 
 **Dictionary value nullability narrowing** (`object?` → `object`):
@@ -585,7 +584,7 @@ __result.ClosedAt = source.ClosedAt.HasValue
 #### 4b. Generic Wrapper Unwrapping (`Wrapper<T> → T`)
 
 The generator detects when:
-1. The source property type is a generic type `W<T>` (any single-type-parameter generic)
+1. The source property type is an allowlisted generic wrapper type `W<T>` (in v1.6, only `StringEnum<T>`)
 2. The destination property type is `T` (the generic type argument)
 3. `W<T>` has a public property named `Value` of type `T`
 
@@ -621,15 +620,14 @@ This is intentionally narrow to avoid false positives and surprising runtime beh
 
 Built-in type coercions slot into the existing property assignment priority:
 
-1. Explicit `[ForgeProperty]` / `[ForgeFrom]` / `[Ignore]` / `[ForgeWith]`
-2. Per-property `ConvertWith` (Feature 3)
-3. Direct name match with compatible types (existing)
-4. Compatible enum casting (existing)
-5. String↔enum auto-conversion (existing)
-6. **Built-in type coercions (new — DateTimeOffset→DateTime, wrapper unwrap)**
-7. Auto-wire inline collections (existing)
-8. Auto-wire forge methods (existing)
-9. Unmapped → FM0006
+1. Explicit `[ForgeProperty]` remapping, `[ForgeFrom]`, `[Ignore]`, `[ForgeWith]`, or `[ForgeProperty(ConvertWith = ...)]`
+2. Direct name match with compatible types (existing)
+3. Compatible enum casting (existing)
+4. String↔enum auto-conversion (existing)
+5. **Built-in type coercions (new — DateTimeOffset→DateTime, wrapper unwrap)**
+6. Auto-wire inline collections (existing)
+7. Auto-wire forge methods (existing)
+8. Unmapped → FM0006
 
 ### Interaction with Existing Features
 

--- a/docs/SPEC-v1.6-migration-features.md
+++ b/docs/SPEC-v1.6-migration-features.md
@@ -155,7 +155,7 @@ This is a **behavioral change** from v1.5. Projects that relied on `Enum.Parse` 
 |--------|-----------|---------|---------------|
 | Null string → enum | `default(T)` | `Enum.Parse` (throws) | `default(T)` |
 | Empty string → enum | `default(T)` | `Enum.Parse` (throws) | `default(T)` |
-| Configuration | None (always default) | None | `StringToEnum` mode + `NullPropertyHandling` |
+| Configuration | None (always default) | None | `StringToEnumConversion` mode + `NullPropertyHandling` |
 
 ---
 
@@ -220,7 +220,9 @@ dest.Metadata = source.Metadata?.ToDictionary(
 // Widening: safe, but generic variance requires explicit conversion
 dest.Items = source.Items is IReadOnlyList<string?> __cast_Items
     ? __cast_Items
-    : source.Items?.Select(__item => (string?)__item).ToList();
+    : source.Items is { } __v_Items
+        ? __v_Items.Select(__item => (string?)__item).ToList()
+        : null!;
 ```
 
 **List/sequence element nullability narrowing** (`T?` → `T`):

--- a/docs/SPEC-v1.6-migration-features.md
+++ b/docs/SPEC-v1.6-migration-features.md
@@ -1,4 +1,4 @@
-# ForgeMap v1.6 Specification — Migration-Priority Features (Part 2)
+# ForgeMap v1.6 Specification — Migration-Priority Features
 
 ## Overview
 
@@ -42,13 +42,13 @@ private static FileType ResolveType(Source s)
 
 ### Design
 
-When converting `string` or `string?` to an enum type, the generator wraps the conversion in a `string.IsNullOrEmpty` guard. This applies to both `StringToEnum.Parse` and `StringToEnum.TryParse` modes. The guard returns `default(TEnum)` for null/empty strings.
+When converting `string` or `string?` to an enum type, the generator wraps the conversion in a `string.IsNullOrEmpty` guard. This applies to both `StringToEnumConversion.Parse` and `StringToEnumConversion.TryParse` modes. The guard returns `default(TEnum)` for null/empty strings.
 
 This is a behavioral change from v1.5 where `Enum.Parse` was called unconditionally. The new behavior is safer — `Enum.Parse(null)` and `Enum.Parse("")` are always errors, never intentional.
 
 ### Generated Code
 
-**`StringToEnum.Parse` (default):**
+**`StringToEnumConversion.Parse` (default):**
 
 ```csharp
 // v1.5: Enum.Parse throws on null/empty
@@ -60,12 +60,12 @@ dest.Type = string.IsNullOrEmpty(source.Type)
     : (FileType)global::System.Enum.Parse(typeof(FileType), source.Type, true);
 ```
 
-**`StringToEnum.TryParse`:**
+**`StringToEnumConversion.TryParse`:**
 
 ```csharp
-// v1.5: TryParse already handles null gracefully (returns false, default),
-// but empty string "" parses to 0 silently which may be surprising.
-// v1.6: explicit guard for consistency
+// v1.5: TryParse already handles null and empty gracefully (returns false, out = default),
+// but without an explicit guard the generated code structure differs from Parse mode.
+// v1.6: explicit guard for consistency across both modes
 dest.Type = !string.IsNullOrEmpty(source.Type)
     && global::System.Enum.TryParse<FileType>(source.Type, true, out var __enumVal_Type)
     ? __enumVal_Type
@@ -84,7 +84,7 @@ dest.Type = string.IsNullOrEmpty(source.Type!)
 
 // NullPropertyHandling.ThrowException + Parse
 dest.Type = source.Type is null
-    ? throw new global::System.ArgumentNullException("source.Type")
+    ? throw new global::System.ArgumentNullException(nameof(source.Type))
     : string.IsNullOrEmpty(source.Type)
         ? default(FileType)
         : (FileType)global::System.Enum.Parse(typeof(FileType), source.Type, true);
@@ -119,9 +119,9 @@ var __result = new Dest(
 
 | Feature | Interaction |
 |---------|-------------|
-| `StringToEnum.Parse` | Guard wraps `Enum.Parse` — returns `default(TEnum)` for null/empty instead of throwing |
-| `StringToEnum.TryParse` | Guard wraps `TryParse` — explicit `IsNullOrEmpty` check for consistency (empty string is no longer silently parsed to 0) |
-| `StringToEnum.None` | No change — auto-conversion disabled, guard not emitted |
+| `StringToEnumConversion.Parse` | Guard wraps `Enum.Parse` — returns `default(TEnum)` for null/empty instead of throwing |
+| `StringToEnumConversion.TryParse` | Guard wraps `TryParse` — explicit `IsNullOrEmpty` check for consistency with `Parse` mode |
+| `StringToEnumConversion.None` | No change — auto-conversion disabled, guard not emitted |
 | `NullPropertyHandling` | Works inside existing null-handling wrappers — the empty-string guard is an orthogonal concern |
 | `[ForgeProperty]` | Applies to explicitly mapped string→enum pairs |
 | `[ForgeFrom]` | Resolver takes precedence — guard not emitted when a resolver is defined |
@@ -140,7 +140,7 @@ var __result = new Dest(
 | `null` string → enum (Parse) | `ArgumentNullException` | `default(TEnum)` |
 | `""` string → enum (Parse) | `ArgumentException` | `default(TEnum)` |
 | `null` string → enum (TryParse) | `default(TEnum)` (TryParse returns false) | `default(TEnum)` (explicit guard) |
-| `""` string → enum (TryParse) | Parses to `(TEnum)0` silently | `default(TEnum)` (explicit guard) |
+| `""` string → enum (TryParse) | `default(TEnum)` (TryParse returns false) | `default(TEnum)` (explicit guard for consistency) |
 | Valid string → enum | `Enum.Parse` / `TryParse` as before | Unchanged |
 | `null` string → nullable enum | Follows `NullPropertyHandling` | `(TEnum?)null` |
 | `""` string → nullable enum | `ArgumentException` (Parse) | `(TEnum?)null` |
@@ -528,7 +528,7 @@ var __result = new Dest(
 
 Two common type mismatches still require manual methods despite ForgeMap's auto-mapping capabilities:
 
-**1. `DateTimeOffset → DateTime`**: Many APIs (Octokit.Webhooks, ASP.NET Core) use `DateTimeOffset`, while domain/DAO models use `DateTime`. The standard lossless conversion is `.UtcDateTime`.
+**1. `DateTimeOffset → DateTime`**: Many APIs (Octokit.Webhooks, ASP.NET Core) use `DateTimeOffset`, while domain/DAO models use `DateTime`. A common conversion is `.UtcDateTime`, which preserves the instant in time as a UTC `DateTime`.
 
 **2. Generic wrapper unwrapping (e.g., `StringEnum<T> → T`)**: Libraries like Octokit.Webhooks wrap enums in `StringEnum<T>` for JSON flexibility. The underlying value is accessible via `.Value`.
 
@@ -567,7 +567,7 @@ __result.ClosedAt = source.ClosedAt?.UtcDateTime ?? default!;
 __result.ClosedAt = source.ClosedAt?.UtcDateTime ?? default(DateTime);
 // ThrowException:
 __result.ClosedAt = source.ClosedAt?.UtcDateTime
-    ?? throw new global::System.ArgumentNullException("source.ClosedAt");
+    ?? throw new global::System.ArgumentNullException(nameof(source.ClosedAt));
 ```
 
 The reverse direction (`DateTime → DateTimeOffset`) is also supported via the implicit conversion (`new DateTimeOffset(dateTime)`):
@@ -608,12 +608,14 @@ __result.Type = source.Type?.Value ?? default(UserType);
 **Matching criteria for generic wrapper detection:**
 
 1. Source type must be a named type with exactly one type argument: `W<T>`
-2. Source type must have a public, non-static property named `Value`
-3. The `Value` property's return type must match the destination property type (or be assignable after stripping nullable annotations)
-4. The destination type must be `T` (the type argument of `W<T>`)
-5. Not triggered when the destination type is `W<T>` (same wrapper type — that's a direct assignment)
+2. Source type must be an allowlisted wrapper type. For v1.6, the built-in allowlist contains only `StringEnum<T>` (from `Octokit.Webhooks.Models`). Future versions may expand the allowlist or add an opt-in attribute for user-defined wrappers
+3. Source type must have a public, non-static property named `Value`
+4. The `Value` property's return type must match the destination property type (or be assignable after stripping nullable annotations)
+5. The destination type must be `T` (the type argument of `W<T>`)
+6. Not triggered when the destination type is `W<T>` (same wrapper type — that's a direct assignment)
+7. Explicitly excluded: `Nullable<T>` (handled by existing nullable logic) and `Lazy<T>` (`.Value` has side effects)
 
-This is intentionally narrow to avoid false positives. The `Value` property name is a well-established convention (`Nullable<T>.Value`, `StronglyTypedId<T>.Value`, `StringEnum<T>.Value`).
+This is intentionally narrow to avoid false positives and surprising runtime behavior. Types like `Lazy<T>` have `.Value` properties that trigger computation or throw, so a generic "any type with `.Value`" rule would be unsafe. Only known pure wrappers participate in auto-unwrapping.
 
 ### Precedence
 
@@ -653,10 +655,10 @@ Built-in type coercions slot into the existing property assignment priority:
 | `DateTimeOffset` → `DateTime` | `.UtcDateTime` |
 | `DateTimeOffset?` → `DateTime?` | `?.UtcDateTime` |
 | `DateTime` → `DateTimeOffset` | Direct assignment (implicit conversion) |
-| `Wrapper<T>` → `T` (with `.Value` property) | `.Value` |
+| `Wrapper<T>` → `T` (allowlisted wrapper with `.Value` property) | `.Value` |
 | `Wrapper<T>?` → `T?` | `?.Value` |
 | `T` → `Wrapper<T>` | Not auto-reversed — use `[ForgeProperty(ConvertWith = ...)]` |
-| No `.Value` property on wrapper type | No coercion — falls through to auto-wire |
+| No `.Value` property on wrapper type or not allowlisted | No coercion — falls through to auto-wire |
 
 ### Competitor Comparison
 
@@ -1033,7 +1035,7 @@ All v1.6 features work within the existing attribute surface (one new property o
 
 v1.6 introduces two behavioral changes that may affect existing forgers:
 
-1. **String→enum null/empty handling (Feature 1)** — `Enum.Parse` on null/empty strings now returns `default(TEnum)` instead of throwing. This is safer but may change behavior for projects that relied on the exception. For projects using `StringToEnum.TryParse`, empty strings (`""`) now return `default(TEnum)` instead of being silently parsed to `(TEnum)0` — this is more consistent but may change behavior if your enums have meaningful zero values. **To preserve v1.5 behavior**: use `[ForgeFrom]` with an explicit resolver that calls `Enum.Parse` without the guard.
+1. **String→enum null/empty handling (Feature 1)** — `Enum.Parse` on null/empty strings now returns `default(TEnum)` instead of throwing. This is safer but may change behavior for projects that relied on the exception. For projects using `StringToEnumConversion.TryParse`, the generated code now includes an explicit `IsNullOrEmpty` guard for consistency, though runtime behavior is unchanged since `TryParse` already returns `false` for null/empty. **To preserve v1.5 behavior**: use `[ForgeFrom]` with an explicit resolver that calls `Enum.Parse` without the guard.
 
 2. **Constructor preference for get-only types (Feature 5)** — The generator now prefers parameterized constructors when the destination type has get-only properties with matching source properties. This may activate constructor-based mapping for types that previously used the parameterless constructor. **To preserve v1.5 behavior**: set `ConstructorPreference = ConstructorPreference.PreferParameterless` on the forger or assembly.
 
@@ -1048,7 +1050,7 @@ v1.6 introduces two behavioral changes that may affect existing forgers:
 | Limitation | Reason | Workaround |
 |-----------|--------|------------|
 | Built-in type coercions are not user-extensible | Hard-coded to avoid combinatorial complexity; per-property `ConvertWith` covers custom cases | Use `[ForgeProperty(ConvertWith = ...)]` for any coercion not built in |
-| Generic wrapper unwrap only matches `.Value` property | Narrow detection to avoid false positives | Use `[ForgeProperty(ConvertWith = ...)]` for wrappers with different accessor names |
+| Generic wrapper unwrap only matches allowlisted types (v1.6: `StringEnum<T>`) | Narrow detection via allowlist to avoid side effects from types like `Lazy<T>` | Use `[ForgeProperty(ConvertWith = ...)]` for wrappers not on the allowlist |
 | Reverse direction not supported for `T → Wrapper<T>` | No general way to construct a wrapper from its inner value | Use explicit `[ForgeProperty(ConvertWith = ...)]` on the reverse method |
 | Constructor preference may select unexpected constructor | Auto-detection is based on get-only property coverage heuristic | Use `ConstructorPreference.PreferParameterless` to opt out |
 | String→enum empty-string guard always uses `default(TEnum)` | No configuration for custom empty-string behavior | Use `[ForgeFrom]` resolver for custom empty-string logic |


### PR DESCRIPTION
## Summary

- Adds `SPEC-v1.6-migration-features.md` covering issues #108–#112, five migration-priority features identified during the OpenPublishing.Build AutoMapper→ForgeMap migration
- Renames old v1.6 spec (auto-flattening #82, dictionary mapping #83) to `SPEC-future-advanced-mapping.md` with renumbered diagnostics (FM0053–FM0058)
- Updates all cross-references in v1.4, v1.5, comparison doc, and DocFX specs index

### v1.6 Features

| # | Feature | Issue | Diagnostics |
|---|---------|-------|-------------|
| 1 | Null/empty string→enum: default instead of throwing | #109 | FM0046 |
| 2 | Nullable-safe collection coercion (CS8620) | #110 | FM0047 |
| 3 | Per-property `ConvertWith` on `[ForgeProperty]` | #111 | FM0048–FM0049 |
| 4 | Built-in type coercions (DateTimeOffset→DateTime, wrapper unwrap) | #112 | FM0050 |
| 5 | Constructor preference for get-only destination types | #108 | FM0051–FM0052 |

### API Changes
- 1 new enum: `ConstructorPreference` (Auto, PreferParameterless)
- 1 new property on `ForgePropertyAttribute`: `ConvertWith` (string?)
- 2 new config properties on `ForgeMapAttribute`/`ForgeMapDefaultsAttribute`: `ConstructorPreference`

## Test plan
- [ ] Verify all markdown links resolve correctly (no broken cross-references)
- [ ] Verify diagnostic codes FM0046–FM0052 (v1.6) don't overlap with FM0053–FM0058 (future)
- [ ] Review generated code examples for syntactic correctness
- [ ] Verify DocFX site builds with the new spec files