### PR TITLE
chore: prepare v1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## v1.6.0
+
+### New Features
+
+- **Enhanced constructor-based mapping** — New `[ForgeConstructor]` attribute and `ConstructorPreference` enum (`Auto`, `PreferParameterless`) on `[ForgeMap]`/`[ForgeMapDefaults]` for explicit constructor selection. Parameters are matched by name to source properties and `[ForgeProperty]` mappings; unmatched optional parameters receive their declared default values. Adds FM0046 (warning for unmatched parameters), FM0047 (error for specified constructor not found), and FM0048 (disabled routing info).
+
+- **Null-safe string→enum conversion** — String-to-enum mappings now emit null-safe code. When the source is nullable, a null/empty guard returns the enum default instead of throwing. `StrictParse` mode is available for validation scenarios. Adds FM0049 (disabled info diagnostic).
+
+- **Nullable-safe collection coercion** — Collection coercion now handles nullable element types correctly, avoiding CS8620 warnings. Supports `List<T?>` → `IReadOnlyList<T?>` and similar patterns. Adds FM0050 (disabled info) and FM0051 (warning for unsupported patterns).
+
+- **Per-property ConvertWith** — `ForgePropertyAttribute.ConvertWith` allows specifying a converter method or type per property, supporting both method names and `ITypeConverter<TSource, TDest>` type references with DI resolution. Adds FM0052 (warning for method not found), FM0053 (warning for signature mismatch), and FM0054 (disabled info).
+
+- **DateTimeOffset→DateTime auto-coercion** — Automatic conversion from `DateTimeOffset` to `DateTime` via `.UtcDateTime`, with full `NullPropertyHandling` support for nullable variants.
+
+### Bug Fixes
+
+- Fixed duplicate FM0014 emission for unmatched constructor parameters in explicit-constructor path
+- Fixed culture-sensitive decimal separators in generated numeric literals (FormatLiteral now uses invariant culture)
+- Fixed per-property ConvertWith being silently ignored in normal mappings
+- Fixed DateTimeOffset? coercion bypassing NullPropertyHandling pipeline
+- Fixed ConvertWith expressions for lifted value types using explicit cast instead of null-forgiving operator
+- Fixed dictionary coercion for unsupported types (SortedDictionary, ConcurrentDictionary) returning null for proper FM0051 reporting
+- Fixed character and string literal escaping using Roslyn's SymbolDisplay.FormatLiteral
+- Fixed enum default expressions using FullyQualifiedFormat for cross-namespace resolution
+- Inherited ConvertWith mappings through IncludeBaseForge with first-wins semantics
+
+### New Diagnostics
+
+| Rule ID | Severity | Description |
+|---------|----------|-------------|
+| FM0046 | Warning | Unmatched constructor parameter |
+| FM0047 | Error | Specified constructor not found |
+| FM0048 | Disabled | Constructor mapping routing info |
+| FM0049 | Disabled | Null-safe guard applied to string→enum conversion |
+| FM0050 | Disabled | Nullable-safe collection coercion applied |
+| FM0051 | Warning | Unsupported nullable collection coercion |
+| FM0052 | Warning | Per-property converter method not found |
+| FM0053 | Warning | Per-property converter signature mismatch |
+| FM0054 | Disabled | Per-property converter applied |
+
 ## v1.5.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed character and string literal escaping using Roslyn's SymbolDisplay.FormatLiteral
 - Fixed enum default expressions using FullyQualifiedFormat for cross-namespace resolution
 - Inherited ConvertWith mappings through IncludeBaseForge with first-wins semantics
+- Fixed `NullPropertyHandling` strategies (`CoalesceToNew`, `CoalesceToDefault`, `ThrowException`, `SkipNull`) being ignored for `Nullable<T>` → `T` value type mappings — previously always generated a forced unwrap that threw on null (#115)
 
 ### New Diagnostics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - **DateTimeOffset→DateTime auto-coercion** — Automatic conversion from `DateTimeOffset` to `DateTime` via `.UtcDateTime`, with full `NullPropertyHandling` support for nullable variants.
 
+- **Multi-Roslyn targeting for .NET 8/9/10 SDK compatibility** — The NuGet package now ships three analyzer variants compiled against Roslyn 4.8.0, 4.12.0, and 5.0.0, so consumers on .NET 8, 9, or 10 SDKs automatically get the correct binary. Includes pack scripts (`build/pack.sh`, `build/pack.ps1`) for the multi-build workflow and an MSBuild guard against bare `dotnet pack`.
+
 ### Bug Fixes
 
 - Fixed duplicate FM0014 emission for unmatched constructor parameters in explicit-constructor path

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
     <Copyright>Copyright (c) ForgeMap Contributors</Copyright>
 
     <!-- Versioning -->
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
 
     <!-- SourceLink & deterministic builds -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/ForgeMap.Generator/AnalyzerReleases.Shipped.md
+++ b/src/ForgeMap.Generator/AnalyzerReleases.Shipped.md
@@ -1,6 +1,22 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 1.6.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+FM0046 | ForgeMap | Warning | Unmatched constructor parameter
+FM0047 | ForgeMap | Error | Specified constructor not found
+FM0048 | ForgeMap | Disabled | Constructor mapping routing info
+FM0049 | ForgeMap | Disabled | Null-safe guard applied to string→enum conversion
+FM0050 | ForgeMap | Disabled | Nullable-safe collection coercion applied
+FM0051 | ForgeMap | Warning | Unsupported nullable collection coercion
+FM0052 | ForgeMap | Warning | Per-property converter method not found
+FM0053 | ForgeMap | Warning | Per-property converter signature mismatch
+FM0054 | ForgeMap | Disabled | Per-property converter applied
+
 ## Release 1.5.0
 
 ### New Rules

--- a/src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md
@@ -5,12 +5,3 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-FM0046 | ForgeMap | Warning | Unmatched constructor parameter
-FM0047 | ForgeMap | Error | Specified constructor not found
-FM0048 | ForgeMap | Disabled | Constructor mapping routing info
-FM0049 | ForgeMap | Disabled | Null-safe guard applied to string→enum conversion
-FM0050 | ForgeMap | Disabled | Nullable-safe collection coercion applied
-FM0051 | ForgeMap | Warning | Unsupported nullable collection coercion
-FM0052 | ForgeMap | Warning | Per-property converter method not found
-FM0053 | ForgeMap | Warning | Per-property converter signature mismatch
-FM0054 | ForgeMap | Disabled | Per-property converter applied

--- a/tests/ForgeMap.Tests/BasicMappingTestForgers.cs
+++ b/tests/ForgeMap.Tests/BasicMappingTestForgers.cs
@@ -393,3 +393,24 @@ public partial class ConvertWithForger
 }
 
 #endregion
+
+#region v1.6 Per-Property ConvertWith
+
+// --- Forger with per-property [ForgeProperty(ConvertWith = ...)] ---
+
+[ForgeMap]
+public partial class PropertyConvertWithForger
+{
+    [ForgeProperty(nameof(PropertyConvertWithSource.UserType), nameof(PropertyConvertWithDest.UserTypeCode), ConvertWith = nameof(ConvertUserType))]
+    public partial PropertyConvertWithDest Forge(PropertyConvertWithSource source);
+
+    private static int ConvertUserType(string userType) => userType switch
+    {
+        "Admin" => 1,
+        "Editor" => 2,
+        "Viewer" => 3,
+        _ => 0,
+    };
+}
+
+#endregion

--- a/tests/ForgeMap.Tests/BasicMappingTestModels.cs
+++ b/tests/ForgeMap.Tests/BasicMappingTestModels.cs
@@ -504,3 +504,21 @@ public class ConvertWithSourceToDestConverter : ITypeConverter<ConvertWithSource
 }
 
 #endregion
+
+#region v1.6 Per-Property ConvertWith Models
+
+public class PropertyConvertWithSource
+{
+    public int Id { get; set; }
+    public string UserType { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}
+
+public class PropertyConvertWithDest
+{
+    public int Id { get; set; }
+    public int UserTypeCode { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+#endregion

--- a/tests/ForgeMap.Tests/BasicMappingTests.cs
+++ b/tests/ForgeMap.Tests/BasicMappingTests.cs
@@ -1574,3 +1574,33 @@ public class ConvertWithTests
 }
 
 #endregion
+
+#region v1.6 Per-Property ConvertWith Tests
+
+public class PropertyConvertWithTests
+{
+    private readonly PropertyConvertWithForger _forger = new();
+
+    [Fact]
+    public void PerPropertyConvertWith_ShouldApplyConverterMethod()
+    {
+        var source = new PropertyConvertWithSource { Id = 42, UserType = "Admin", Name = "Alice" };
+        var result = _forger.Forge(source);
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be(42);
+        result.Name.Should().Be("Alice");
+        result.UserTypeCode.Should().Be(1);
+    }
+
+    [Fact]
+    public void PerPropertyConvertWith_UnknownType_ShouldReturnDefault()
+    {
+        var source = new PropertyConvertWithSource { Id = 1, UserType = "Unknown", Name = "Bob" };
+        var result = _forger.Forge(source);
+
+        result.UserTypeCode.Should().Be(0);
+    }
+}
+
+#endregion


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` to `1.6.0` in `Directory.Build.props`
- Ship FM0046–FM0054 analyzer rules (move from `Unshipped` to `Shipped`)
- Add v1.6.0 section to `CHANGELOG.md` covering five new features, nine bug fixes, and nine new diagnostics

### v1.6.0 Features

- **Enhanced constructor-based mapping** — `[ForgeConstructor]`, `ConstructorPreference` enum
- **Null-safe string→enum conversion** — null/empty guard with `StrictParse` mode
- **Nullable-safe collection coercion** — avoids CS8620 warnings
- **Per-property ConvertWith** — method or `ITypeConverter` per property with DI support
- **DateTimeOffset→DateTime auto-coercion** — via `.UtcDateTime` with `NullPropertyHandling`

## Test plan

- [x] 309 tests passing on both net8.0 and net9.0
- [x] 0 warnings, 0 errors on build
- [ ] CI passes on PR
- [ ] Tag `v1.6.0` after merge