### PR TITLE
fix: respect NullPropertyHandling for Nullable<T>→T value type mappings

### DIFF
--- a/src/ForgeMap.Generator/ForgeCodeEmitter.ForgeIntoMethod.cs
+++ b/src/ForgeMap.Generator/ForgeCodeEmitter.ForgeIntoMethod.cs
@@ -428,10 +428,23 @@ internal sealed partial class ForgeCodeEmitter
 
         if (sourceProp != null && CanAssign(sourceProp.Type, destProp.Type))
         {
-            // Handle Nullable<T> to T conversion using explicit cast which throws if null
+            // Handle Nullable<T> to T conversion — respect NullPropertyHandling strategy
             if (IsNullableToNonNullableValueType(sourceProp.Type, destProp.Type))
             {
-                sb.AppendLine($"            {destParam}.{destProp.Name} = ({destProp.Type.ToDisplayString()}){sourceParam}.{sourceProp.Name}!;");
+                var strategy = ResolveNullPropertyHandling(destProp.Name, nullPropertyHandlingOverrides);
+                var sourceExprVal = $"{sourceParam}.{sourceProp.Name}";
+                if (strategy == 1) // SkipNull
+                {
+                    sb.AppendLine($"            if ({sourceExprVal} is {{ }} __val_{destProp.Name})");
+                    sb.AppendLine($"            {{");
+                    sb.AppendLine($"                {destParam}.{destProp.Name} = __val_{destProp.Name};");
+                    sb.AppendLine($"            }}");
+                }
+                else
+                {
+                    var handledExpr = ApplyNullableValueTypeCtorHandling(sourceExprVal, destProp.Type, destProp.Name, destProp.ContainingType.Name, strategy);
+                    sb.AppendLine($"            {destParam}.{destProp.Name} = {handledExpr};");
+                }
             }
             else if (IsNullableToNonNullableReferenceType(sourceProp.Type, destProp.Type))
             {

--- a/src/ForgeMap.Generator/ForgeCodeEmitter.NullHandling.cs
+++ b/src/ForgeMap.Generator/ForgeCodeEmitter.NullHandling.cs
@@ -219,4 +219,89 @@ internal sealed partial class ForgeCodeEmitter
         }
         return false;
     }
+
+    /// <summary>
+    /// Applies NullPropertyHandling to a Nullable&lt;T&gt; → T value type assignment in property initializers.
+    /// Returns the expression string, or null when SkipNull applies (added to skipNullAssignments).
+    /// </summary>
+    private string? ApplyNullableValueTypeHandling(
+        string sourceExpr,
+        ITypeSymbol destType,
+        string destPropertyName,
+        string destTypeName,
+        int strategy,
+        List<(string DestPropName, string SourceExpr, string LocalVarName, string? AssignExpr)>? skipNullAssignments,
+        IPropertySymbol destProp)
+    {
+        var destDisplay = destType.ToDisplayString();
+        var isParenNeeded = sourceExpr.Contains("?.");
+
+        switch (strategy)
+        {
+            case 0: // NullForgiving — existing behavior: forced unwrap
+                return isParenNeeded
+                    ? $"({destDisplay})({sourceExpr})!"
+                    : $"({destDisplay}){sourceExpr}!";
+
+            case 1: // SkipNull
+                if (skipNullAssignments == null || destProp.SetMethod?.IsInitOnly == true)
+                    return isParenNeeded
+                        ? $"({destDisplay})({sourceExpr})!"
+                        : $"({destDisplay}){sourceExpr}!";
+                var localVar = $"__val_{destPropertyName}";
+                skipNullAssignments.Add((destPropertyName, sourceExpr, localVar, null));
+                return null;
+
+            case 2: // CoalesceToDefault
+                return $"{sourceExpr} ?? default({destDisplay})";
+
+            case 3: // ThrowException
+                return $"{sourceExpr} ?? throw new global::System.ArgumentNullException(\"{destPropertyName}\", \"Cannot assign null source property '{sourceExpr}' to non-nullable destination '{destTypeName}.{destPropertyName}'.\")";
+
+            case 4: // CoalesceToNew — for value types, same as CoalesceToDefault
+                return $"{sourceExpr} ?? default({destDisplay})";
+
+            default:
+                return isParenNeeded
+                    ? $"({destDisplay})({sourceExpr})!"
+                    : $"({destDisplay}){sourceExpr}!";
+        }
+    }
+
+    /// <summary>
+    /// Applies NullPropertyHandling to a Nullable&lt;T&gt; → T value type for constructor parameters.
+    /// SkipNull is not applicable for ctor params — callers should remap to NullForgiving before calling.
+    /// </summary>
+    private static string ApplyNullableValueTypeCtorHandling(
+        string sourceExpr,
+        ITypeSymbol destType,
+        string destPropertyName,
+        string destTypeName,
+        int strategy)
+    {
+        var destDisplay = destType.ToDisplayString();
+        var isParenNeeded = sourceExpr.Contains("?.");
+
+        switch (strategy)
+        {
+            case 0: // NullForgiving
+                return isParenNeeded
+                    ? $"({destDisplay})({sourceExpr})!"
+                    : $"({destDisplay}){sourceExpr}!";
+
+            case 2: // CoalesceToDefault
+                return $"{sourceExpr} ?? default({destDisplay})";
+
+            case 3: // ThrowException
+                return $"{sourceExpr} ?? throw new global::System.ArgumentNullException(\"{destPropertyName}\", \"Cannot assign null source property '{sourceExpr}' to non-nullable destination '{destTypeName}.{destPropertyName}'.\")";
+
+            case 4: // CoalesceToNew — for value types, same as CoalesceToDefault
+                return $"{sourceExpr} ?? default({destDisplay})";
+
+            default:
+                return isParenNeeded
+                    ? $"({destDisplay})({sourceExpr})!"
+                    : $"({destDisplay}){sourceExpr}!";
+        }
+    }
 }

--- a/src/ForgeMap.Generator/ForgeCodeEmitter.PropertyAssignment.cs
+++ b/src/ForgeMap.Generator/ForgeCodeEmitter.PropertyAssignment.cs
@@ -76,7 +76,14 @@ internal sealed partial class ForgeCodeEmitter
                     return enumCast;
             }
             if (isLiftedValueType && destProp.Type.IsValueType && GetNullableUnderlyingType(destProp.Type) == null)
-                return $"({destProp.Type.ToDisplayString()})({sourceExpr})!";
+            {
+                var strategy = ResolveNullPropertyHandling(destProp.Name, nullPropertyHandlingOverrides);
+                var liftedExpr = ApplyNullableValueTypeHandling(
+                    sourceExpr, destProp.Type, destProp.Name,
+                    destProp.ContainingType.Name, strategy, skipNullAssignments, destProp);
+                if (liftedExpr != null) return liftedExpr;
+                return null;
+            }
 
             // Check for nullable ref → non-nullable ref mismatch
             if (sourceLeafType != null && IsNullableToNonNullableReferenceType(sourceLeafType, destProp.Type))
@@ -209,7 +216,15 @@ internal sealed partial class ForgeCodeEmitter
         if (sourceProp != null && CanAssign(sourceProp.Type, destProp.Type))
         {
             if (IsNullableToNonNullableValueType(sourceProp.Type, destProp.Type))
-                return $"({destProp.Type.ToDisplayString()}){sourceParam}.{sourceProp.Name}!";
+            {
+                var strategy = ResolveNullPropertyHandling(destProp.Name, nullPropertyHandlingOverrides);
+                var nullableValueExpr = ApplyNullableValueTypeHandling(
+                    $"{sourceParam}.{sourceProp.Name}", destProp.Type, destProp.Name,
+                    destProp.ContainingType.Name, strategy, skipNullAssignments, destProp);
+                if (nullableValueExpr != null) return nullableValueExpr;
+                // null means SkipNull was added to skipNullAssignments
+                return null;
+            }
 
             // Check for nullable ref → non-nullable ref mismatch
             if (IsNullableToNonNullableReferenceType(sourceProp.Type, destProp.Type))
@@ -539,7 +554,12 @@ internal sealed partial class ForgeCodeEmitter
         IMethodSymbol method)
     {
         if (sourcePropertyType != null && IsNullableToNonNullableValueType(sourcePropertyType, destPropertyType))
-            return sourceExpression.Contains("?.") ? $"({destPropertyType.ToDisplayString()})({sourceExpression})!" : $"({destPropertyType.ToDisplayString()}){sourceExpression}!";
+        {
+            var strategy = ResolveNullPropertyHandling(destPropertyName, nullPropertyHandlingOverrides);
+            // SkipNull (1) is not applicable for ctor params — fall back to NullForgiving
+            if (strategy == 1) strategy = 0;
+            return ApplyNullableValueTypeCtorHandling(sourceExpression, destPropertyType, destPropertyName, destTypeName, strategy);
+        }
 
         // Handle lifted value type from null-conditional: source.Customer?.Age is int?
         // even though Age is int — cast back to the destination type
@@ -552,7 +572,9 @@ internal sealed partial class ForgeCodeEmitter
             var enumCast = TryGenerateCompatibleEnumCast(sourcePropertyType!, destPropertyType, sourceExpression, isLifted: true);
             if (enumCast != null)
                 return enumCast;
-            return $"({destPropertyType.ToDisplayString()})({sourceExpression})!";
+            var liftedStrategy = ResolveNullPropertyHandling(destPropertyName, nullPropertyHandlingOverrides);
+            if (liftedStrategy == 1) liftedStrategy = 0; // SkipNull → NullForgiving for ctor params
+            return ApplyNullableValueTypeCtorHandling(sourceExpression, destPropertyType, destPropertyName, destTypeName, liftedStrategy);
         }
 
         // Compatible enum cast for constructor parameters

--- a/tests/ForgeMap.Tests/NullPropertyHandlingTests.cs
+++ b/tests/ForgeMap.Tests/NullPropertyHandlingTests.cs
@@ -1054,6 +1054,266 @@ public class NullPropertyHandlingTests
         Assert.Contains("source.Title!", generatedCode);
     }
 
+    [Fact]
+    public void CoalesceToNew_NullableValueType_GeneratesDefaultCoalesce()
+    {
+        // Reproduction from issue #115: DateTime? → DateTime with CoalesceToNew
+        var source = """
+            #nullable enable
+            using System;
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public DateTime? LastBuildTime { get; set; }
+                }
+
+                public class Dest
+                {
+                    public DateTime LastBuildTime { get; set; }
+                }
+
+                [ForgeMap(NullPropertyHandling = NullPropertyHandling.CoalesceToNew)]
+                public partial class TestForger
+                {
+                    public partial Dest Forge(Source source);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Debug.WriteLine($"Generated code:\n{generatedCode}");
+
+        // Should generate ?? default, NOT a forced unwrap
+        Assert.Contains("source.LastBuildTime ?? default(System.DateTime)", generatedCode);
+        Assert.DoesNotContain("LastBuildTime!", generatedCode);
+    }
+
+    [Fact]
+    public void CoalesceToDefault_NullableValueType_GeneratesDefaultCoalesce()
+    {
+        var source = """
+            #nullable enable
+            using System;
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public int? Count { get; set; }
+                }
+
+                public class Dest
+                {
+                    public int Count { get; set; }
+                }
+
+                [ForgeMap(NullPropertyHandling = NullPropertyHandling.CoalesceToDefault)]
+                public partial class TestForger
+                {
+                    public partial Dest Forge(Source source);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Debug.WriteLine($"Generated code:\n{generatedCode}");
+
+        Assert.Contains("source.Count ?? default(int)", generatedCode);
+    }
+
+    [Fact]
+    public void ThrowException_NullableValueType_GeneratesThrow()
+    {
+        var source = """
+            #nullable enable
+            using System;
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public int? Count { get; set; }
+                }
+
+                public class Dest
+                {
+                    public int Count { get; set; }
+                }
+
+                [ForgeMap(NullPropertyHandling = NullPropertyHandling.ThrowException)]
+                public partial class TestForger
+                {
+                    public partial Dest Forge(Source source);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Debug.WriteLine($"Generated code:\n{generatedCode}");
+
+        Assert.Contains("?? throw new global::System.ArgumentNullException", generatedCode);
+    }
+
+    [Fact]
+    public void SkipNull_NullableValueType_GeneratesIfGuard()
+    {
+        var source = """
+            #nullable enable
+            using System;
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public int? Count { get; set; }
+                }
+
+                public class Dest
+                {
+                    public int Count { get; set; }
+                }
+
+                [ForgeMap(NullPropertyHandling = NullPropertyHandling.SkipNull)]
+                public partial class TestForger
+                {
+                    public partial Dest Forge(Source source);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Debug.WriteLine($"Generated code:\n{generatedCode}");
+
+        // SkipNull: should use var result pattern with if guard
+        Assert.Contains("var result = new", generatedCode);
+        Assert.Contains("is { }", generatedCode);
+        Assert.Contains("result.Count =", generatedCode);
+    }
+
+    [Fact]
+    public void NullForgiving_NullableValueType_DefaultBehavior()
+    {
+        var source = """
+            #nullable enable
+            using System;
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public int? Count { get; set; }
+                }
+
+                public class Dest
+                {
+                    public int Count { get; set; }
+                }
+
+                [ForgeMap(NullPropertyHandling = NullPropertyHandling.NullForgiving)]
+                public partial class TestForger
+                {
+                    public partial Dest Forge(Source source);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Debug.WriteLine($"Generated code:\n{generatedCode}");
+
+        // NullForgiving should keep the forced unwrap behavior
+        Assert.Contains("(int)source.Count!", generatedCode);
+    }
+
+    [Fact]
+    public void ForgeInto_CoalesceToNew_NullableValueType_GeneratesDefaultCoalesce()
+    {
+        var source = """
+            #nullable enable
+            using System;
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public DateTime? LastBuildTime { get; set; }
+                }
+
+                public class Dest
+                {
+                    public DateTime LastBuildTime { get; set; }
+                }
+
+                [ForgeMap(NullPropertyHandling = NullPropertyHandling.CoalesceToNew)]
+                public partial class TestForger
+                {
+                    public partial void ForgeInto(Source source, [UseExistingValue] Dest dest);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Debug.WriteLine($"Generated code:\n{generatedCode}");
+
+        Assert.Contains("source.LastBuildTime ?? default(System.DateTime)", generatedCode);
+    }
+
+    [Fact]
+    public void ConstructorMapping_CoalesceToNew_NullableValueType_GeneratesDefaultCoalesce()
+    {
+        var source = """
+            #nullable enable
+            using System;
+            using ForgeMap;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public int? Value { get; set; }
+                }
+
+                public class Dest
+                {
+                    public int Value { get; }
+                    public Dest(int value) { Value = value; }
+                }
+
+                [ForgeMap(NullPropertyHandling = NullPropertyHandling.CoalesceToNew)]
+                public partial class TestForger
+                {
+                    public partial Dest Forge(Source source);
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        var generatedCode = generatedTrees[0].GetText().ToString();
+        Debug.WriteLine($"Generated code:\n{generatedCode}");
+
+        Assert.Contains("source.Value ?? default(int)", generatedCode);
+    }
+
     private static (IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<SyntaxTree> GeneratedTrees) RunGenerator(string source)
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(source);


### PR DESCRIPTION
## Summary

- **Fixes #115**: `CoalesceToNew` (and other `NullPropertyHandling` strategies) were ignored for `Nullable<T>` → `T` value type mappings because the codegen returned a forced unwrap (`(T)source.Prop!`) before consulting the strategy
- All four code paths now respect the configured strategy: convention property matching, `[ForgeProperty]` with null-conditional chains, constructor parameter mapping, and `ForgeInto` methods
- Added two new helpers (`ApplyNullableValueTypeHandling`, `ApplyNullableValueTypeCtorHandling`) in `NullHandling.cs` that generate the correct expression per strategy (`?? default(T)` for CoalesceToDefault/CoalesceToNew, `?? throw` for ThrowException, `is { }` guard for SkipNull)

## Test plan

- [x] Added 8 new tests covering all `NullPropertyHandling` strategies for nullable value types across Forge, ForgeInto, and constructor mapping paths
- [x] All 316 tests pass on both .NET 8 and .NET 9
- [ ] Verify generated code for `DateTime? → DateTime` with `CoalesceToNew` produces `source.LastBuildTime ?? default(System.DateTime)` instead of `(DateTime)source.LastBuildTime!`