### PR TITLE
chore: improve NuGet package tags and description for discoverability

### DIFF
--- a/src/ForgeMap.Abstractions/ForgeMap.Abstractions.csproj
+++ b/src/ForgeMap.Abstractions/ForgeMap.Abstractions.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
 
     <Description>Attributes and interfaces for ForgeMap, a compile-time object transformation library.</Description>
-    <PackageTags>automapper;mapping;sourcegenerator;dto;transformation</PackageTags>
+    <PackageTags>mapper;mapping;object-mapper;source-generator;automapper;dto;compile-time;roslyn</PackageTags>
 
     <!-- Generate XML docs -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/ForgeMap.Generator/ForgeMap.Generator.csproj
+++ b/src/ForgeMap.Generator/ForgeMap.Generator.csproj
@@ -20,7 +20,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <Description>Source generator for ForgeMap that generates type transformation code at compile time.</Description>
-    <PackageTags>automapper;mapping;sourcegenerator;dto;transformation;roslyn</PackageTags>
+    <PackageTags>mapper;mapping;object-mapper;source-generator;automapper;dto;compile-time;roslyn;code-generation</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
 
     <!-- Only the main ForgeMap package is published -->

--- a/src/ForgeMap/ForgeMap.csproj
+++ b/src/ForgeMap/ForgeMap.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
 
-    <Description>ForgeMap is a lightweight, compile-time object transformation library for .NET. Zero-reflection, source-generator-based mapping with compile-time type safety.</Description>
-    <PackageTags>automapper;mapping;sourcegenerator;dto;transformation;object-mapper</PackageTags>
+    <Description>Compile-time object mapper for .NET using Roslyn source generators. Zero runtime reflection, MIT licensed. Supports property mapping, reverse mapping, nested objects, collections, enums, constructor mapping, and custom converters.</Description>
+    <PackageTags>mapper;mapping;object-mapper;source-generator;automapper;automapper-alternative;dto;compile-time;roslyn;code-generation;dotnet;csharp</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
 


### PR DESCRIPTION
## Summary

Improve NuGet package metadata to make ForgeMap more discoverable when people search for AutoMapper alternatives.

### Tags
**Before**: `automapper;mapping;sourcegenerator;dto;transformation;object-mapper`
**After**: `mapper;mapping;object-mapper;source-generator;automapper;automapper-alternative;dto;compile-time;roslyn;code-generation;dotnet;csharp`

Key additions: `automapper-alternative`, `source-generator` (hyphenated for NuGet search), `compile-time`, `mapper`

### Description
**Before**: Generic "lightweight, compile-time object transformation library" phrasing
**After**: Lists concrete features — property mapping, reverse mapping, nested objects, collections, enums, constructor mapping, custom converters

### GitHub repo metadata (already applied)
- Repo description set
- 15 topics added including `automapper-alternative`, `csharp-sourcegenerator`, `dotnet-core`