### PR TITLE
docs: add community standards files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: Report a bug in ForgeMap
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: dotnet-version
+    attributes:
+      label: .NET Version
+      options:
+        - .NET 8
+        - .NET 9
+        - .NET 10
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: forgemap-version
+    attributes:
+      label: ForgeMap Version
+      placeholder: "e.g., 1.0.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Define source/destination types...
+        2. Add [MapTo] attribute...
+        3. Build the project...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: textarea
+    id: generated-code
+    attributes:
+      label: Generated Code
+      description: If applicable, paste the code ForgeMap generated.
+      render: csharp
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a Security Vulnerability
+    url: https://github.com/superyyrrzz/ForgeMap/security/advisories/new
+    about: Please use GitHub's private vulnerability reporting for security issues. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature Request
+description: Suggest a new feature for ForgeMap
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Why do you need this feature? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-api
+    attributes:
+      label: Proposed API / Syntax
+      description: How would you like to use this feature? Show example code if possible.
+      render: csharp
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches have you considered?
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or references.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,38 @@
+name: Question
+description: Ask a question about ForgeMap
+title: "[Question] "
+labels: ["question"]
+body:
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      options:
+        - Usage
+        - Configuration
+        - Migration from AutoMapper
+        - Migration from Mapperly
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-tried
+    attributes:
+      label: What have you tried?
+      description: Describe what you've already tried or researched.
+    validations:
+      required: true
+
+  - type: textarea
+    id: code-snippets
+    attributes:
+      label: Code Snippets
+      description: If applicable, share relevant code.
+      render: csharp
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context about your question.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,4 @@
 - [ ] Tests pass (`dotnet test`)
 - [ ] No new compiler warnings
 - [ ] Follows existing code patterns
-- [ ] Diagnostics added to `AnalyzerReleases.Unshipped.md` (if new diagnostics)
+- [ ] Diagnostics added to `src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md` (if new diagnostics)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Description
+
+<!-- What does this PR do? -->
+
+## Related Issue
+
+<!-- Link to the issue this PR addresses, e.g., Fixes #123 -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactoring
+- [ ] Other (describe below)
+
+## Checklist
+
+- [ ] Tests pass (`dotnet test`)
+- [ ] No new compiler warnings
+- [ ] Follows existing code patterns
+- [ ] Diagnostics added to `AnalyzerReleases.Unshipped.md` (if new diagnostics)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ dotnet build ForgeMap.slnx
 dotnet test ForgeMap.slnx
 ```
 
-Requires the .NET SDK (see `global.json` for the exact version).
+Requires the .NET SDK (see `global.json` for the minimum SDK version).
 
 ## Code Style
 
@@ -32,7 +32,7 @@ Key things to know:
 
 - The generator runs at compile time inside the IDE and the build pipeline
 - Changes to the generator affect every project that references ForgeMap
-- New diagnostics must be registered in `DiagnosticDescriptors.cs` and tracked in `AnalyzerReleases.Unshipped.md`
+- New diagnostics must be registered in `DiagnosticDescriptors.cs` and tracked in `src/ForgeMap.Generator/AnalyzerReleases.Unshipped.md`
 
 ## Running Benchmarks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to ForgeMap
+
+Thank you for your interest in contributing to ForgeMap! This guide will help you get started.
+
+## How to Contribute
+
+1. **Fork** the repository
+2. **Create a branch** from `main` for your change
+3. **Make your changes** and add tests
+4. **Submit a pull request** using the provided PR template
+
+## Development Setup
+
+```bash
+git clone https://github.com/<your-fork>/ForgeMap.git
+cd ForgeMap
+dotnet build ForgeMap.slnx
+dotnet test ForgeMap.slnx
+```
+
+Requires the .NET SDK (see `global.json` for the exact version).
+
+## Code Style
+
+Follow the `.editorconfig` rules included in the repository. No additional linters or formatters are required.
+
+## Source Generator Notes
+
+ForgeMap is a **Roslyn incremental source generator**. The main entry point is `ForgeCodeEmitter.cs` in `src/ForgeMap.Generator/`.
+
+Key things to know:
+
+- The generator runs at compile time inside the IDE and the build pipeline
+- Changes to the generator affect every project that references ForgeMap
+- New diagnostics must be registered in `DiagnosticDescriptors.cs` and tracked in `AnalyzerReleases.Unshipped.md`
+
+## Running Benchmarks
+
+Benchmarks live in the `benchmarks/` directory:
+
+```bash
+dotnet run -c Release --project benchmarks/ForgeMap.Benchmarks
+```
+
+## Issues and Pull Requests
+
+- Use the provided issue templates when filing bugs, feature requests, or questions
+- Keep pull requests focused — one concern per PR
+- Link your PR to a related issue when applicable
+
+## Commit Conventions
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `docs:` — documentation changes
+- `chore:` — maintenance tasks
+- `refactor:` — code restructuring without behavior change
+
+Example: `feat: add support for nested object mapping`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Follow the `.editorconfig` rules included in the repository. No additional linte
 
 ## Source Generator Notes
 
-ForgeMap is a **Roslyn incremental source generator**. The main entry point is `ForgeCodeEmitter.cs` in `src/ForgeMap.Generator/`.
+ForgeMap is a **Roslyn incremental source generator**. The main entry point is `ForgeMapGenerator.cs` in `src/ForgeMap.Generator/`, which constructs and uses `ForgeCodeEmitter`. The `ForgeCodeEmitter*` files in that directory contain the code emission implementation.
 
 Key things to know:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,10 +17,7 @@ Only the latest released version of ForgeMap receives security updates.
 
 ## Scope
 
-This security policy covers the following NuGet packages:
-
-- `ForgeMap`
-- `ForgeMap.Abstractions`
+This security policy covers the `ForgeMap` NuGet package (which bundles the generator and abstractions).
 
 ## Response Time
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,10 @@ Use [GitHub's private vulnerability reporting](https://github.com/superyyrrzz/Fo
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| Latest release | Yes |
-| Older releases | No |
+| Version        | Supported |
+|----------------|-----------|
+| Latest release | Yes       |
+| Older releases | No        |
 
 Only the latest released version of ForgeMap receives security updates.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Use [GitHub's private vulnerability reporting](https://github.com/superyyrrzz/ForgeMap/security/advisories/new) to report security issues. This ensures the report is only visible to project maintainers until a fix is available.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Yes |
+| Older releases | No |
+
+Only the latest released version of ForgeMap receives security updates.
+
+## Scope
+
+This security policy covers the following NuGet packages:
+
+- `ForgeMap`
+- `ForgeMap.Abstractions`
+
+## Response Time
+
+ForgeMap is a community-maintained open-source project. Security reports are handled on a best-effort basis. There is no SLA, but maintainers will acknowledge reports as quickly as possible.


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with GitHub private vulnerability reporting policy
- Add `CONTRIBUTING.md` with development setup, code style, source generator notes, and commit conventions
- Add issue templates: bug report, feature request, and question (YAML-based GitHub issue forms)
- Add issue template config with security vulnerability redirect
- Add PR template with type-of-change checkboxes and review checklist

## Test plan

- [ ] Verify all issue templates render correctly on GitHub (New Issue page)
- [ ] Verify PR template auto-populates when opening a new pull request
- [ ] Verify `SECURITY.md` links to the correct private reporting URL
- [ ] Confirm GitHub community standards checklist shows improved compliance