### PR TITLE
docs: add AutoMapper migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A lightweight, MIT-licensed, source-generator-based object transformation librar
 - **Debuggable** - Generated code is readable and debuggable
 - **MIT License** - Fully open source, no commercial restrictions
 
+## Coming from AutoMapper?
+
+See the [Migration Guide](docs/migrating-from-automapper.md) for step-by-step instructions and before/after code examples. For a detailed feature comparison with AutoMapper and Mapperly, see [ForgeMap vs AutoMapper & Mapperly](docs/ForgeMap-vs-AutoMapper-and-Mapperly.md).
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A lightweight, MIT-licensed, source-generator-based object transformation librar
 
 ## Coming from AutoMapper?
 
-See the [Migration Guide](docs/migrating-from-automapper.md) for step-by-step instructions and before/after code examples. For a detailed feature comparison with AutoMapper and Mapperly, see [ForgeMap vs AutoMapper & Mapperly](docs/ForgeMap-vs-AutoMapper-and-Mapperly.md).
+See the [Migration Guide](https://github.com/superyyrrzz/ForgeMap/blob/main/docs/migrating-from-automapper.md) for step-by-step instructions and before/after code examples. For a detailed feature comparison with AutoMapper and Mapperly, see [ForgeMap vs AutoMapper & Mapperly](https://github.com/superyyrrzz/ForgeMap/blob/main/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ A lightweight, MIT-licensed, source-generator-based object transformation librar
 - **Debuggable** - Generated code is readable and debuggable
 - **MIT License** - Fully open source, no commercial restrictions
 
-## Coming from AutoMapper?
-
-See the [Migration Guide](https://github.com/superyyrrzz/ForgeMap/blob/main/docs/migrating-from-automapper.md) for step-by-step instructions and before/after code examples. For a detailed feature comparison with AutoMapper and Mapperly, see [ForgeMap vs AutoMapper & Mapperly](https://github.com/superyyrrzz/ForgeMap/blob/main/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md).
-
 ## Installation
 
 ```bash
@@ -72,7 +68,7 @@ See [benchmarks/BENCHMARK_RESULTS.md](benchmarks/BENCHMARK_RESULTS.md) for full 
 
 ## Migrating from AutoMapper
 
-ForgeMap includes an [AI-assisted migration tool](https://github.com/superyyrrzz/ForgeMap/blob/main/.claude/skills/automapper-migration/SKILL.md) (Claude Code skill) that can convert your existing AutoMapper `CreateMap`/`Profile` configurations to ForgeMap attributes automatically. See [ForgeMap vs AutoMapper & Mapperly](https://github.com/superyyrrzz/ForgeMap/blob/main/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md) for a detailed feature comparison.
+See the [Migration Guide](https://github.com/superyyrrzz/ForgeMap/blob/main/docs/migrating-from-automapper.md) for step-by-step instructions and before/after code examples. ForgeMap also includes an [AI-assisted migration tool](https://github.com/superyyrrzz/ForgeMap/blob/main/.claude/skills/automapper-migration/SKILL.md) (Claude Code skill) that can convert your existing AutoMapper `CreateMap`/`Profile` configurations to ForgeMap attributes automatically. See [ForgeMap vs AutoMapper & Mapperly](https://github.com/superyyrrzz/ForgeMap/blob/main/docs/ForgeMap-vs-AutoMapper-and-Mapperly.md) for a detailed feature comparison.
 
 ## Documentation
 

--- a/docs/migrating-from-automapper.md
+++ b/docs/migrating-from-automapper.md
@@ -46,9 +46,11 @@ The generator auto-discovers that `Forge(Address)` should be used for the `Addre
 |---|---|
 | `mapper.Map<UserDto>(user)` | `mapper.Forge(user)` |
 | `mapper.Map(source, dest)` | `mapper.ForgeInto(source, dest)` * |
-| `mapper.Map<List<UserDto>>(users)` | `users?.Select(u => mapper.Forge(u)).ToList()` |
+| `mapper.Map<List<UserDto>>(users)` | `mapper.Forge(users)` ** |
 
 \* `ForgeInto` is a naming convention, not a built-in method. You must declare it as a `partial void` method with a `[UseExistingValue]` parameter — see [Map Into Existing Object](#map-into-existing-object) below.
+
+\** Declare a collection forge method: `public partial List<UserDto> Forge(List<User> source);` — the generator auto-discovers the element-level `Forge(User)` method and implements the body.
 
 **Injection changes:** AutoMapper injects `IMapper`. ForgeMap mappers are plain classes — you can either inject them via DI or use static instances:
 

--- a/docs/migrating-from-automapper.md
+++ b/docs/migrating-from-automapper.md
@@ -46,15 +46,15 @@ The generator auto-discovers that `Forge(Address)` should be used for the `Addre
 |---|---|
 | `mapper.Map<UserDto>(user)` | `mapper.Forge(user)` |
 | `mapper.Map(source, dest)` | `mapper.ForgeInto(source, dest)` * |
-| `mapper.Map<List<UserDto>>(users)` | `users.Select(u => mapper.Forge(u)).ToList()` |
+| `mapper.Map<List<UserDto>>(users)` | `users?.Select(u => mapper.Forge(u)).ToList()` |
 
 \* `ForgeInto` is a naming convention, not a built-in method. You must declare it as a `partial void` method with a `[UseExistingValue]` parameter — see [Map Into Existing Object](#map-into-existing-object) below.
 
 **Injection changes:** AutoMapper injects `IMapper`. ForgeMap mappers are plain classes — you can either inject them via DI or use static instances:
 
 ```csharp
-// Option A: DI (requires Microsoft.Extensions.DependencyInjection)
-// AddForgeMaps() is auto-generated when DI abstractions are referenced.
+// Option A: DI (requires Microsoft.Extensions.DependencyInjection package)
+// AddForgeMaps() is auto-generated when the full DI package is referenced.
 services.AddForgeMaps();
 // constructor: public MyService(AppMapper mapper)
 

--- a/docs/migrating-from-automapper.md
+++ b/docs/migrating-from-automapper.md
@@ -1,0 +1,246 @@
+# Migrating from AutoMapper to ForgeMap
+
+This guide shows how to replace AutoMapper with ForgeMap in your .NET project. ForgeMap is a Roslyn source generator — all mapping code is generated at compile time with zero runtime reflection.
+
+For a detailed feature comparison, see [ForgeMap vs AutoMapper & Mapperly](ForgeMap-vs-AutoMapper-and-Mapperly.md).
+
+## Step 1: Install ForgeMap
+
+```bash
+dotnet remove package AutoMapper
+dotnet remove package AutoMapper.Extensions.Microsoft.DependencyInjection  # if present
+dotnet add package ForgeMap
+```
+
+## Step 2: Replace Profiles with Mapper Classes
+
+AutoMapper uses `Profile` classes with `CreateMap<S, D>()`. ForgeMap uses `[ForgeMap]` partial classes with method signatures.
+
+**Before (AutoMapper):**
+```csharp
+public class UserProfile : Profile
+{
+    public UserProfile()
+    {
+        CreateMap<User, UserDto>();
+        CreateMap<Address, AddressDto>();
+    }
+}
+```
+
+**After (ForgeMap):**
+```csharp
+[ForgeMap]
+public partial class AppMapper
+{
+    public partial UserDto Forge(User source);
+    public partial AddressDto Forge(Address source);
+}
+```
+
+The generator auto-discovers that `Forge(Address)` should be used for the `Address` property on `User` — no extra configuration needed.
+
+## Step 3: Replace Mapping Calls
+
+| AutoMapper | ForgeMap |
+|---|---|
+| `mapper.Map<UserDto>(user)` | `mapper.Forge(user)` |
+| `mapper.Map(source, dest)` | `mapper.ForgeInto(source, dest)` |
+| `mapper.Map<List<UserDto>>(users)` | `users.Select(u => mapper.Forge(u)).ToList()` |
+
+**Injection changes:** AutoMapper injects `IMapper`. ForgeMap mappers are plain classes — you can either inject them via DI (`services.AddForgeMaps()`) or use static instances:
+
+```csharp
+// Option A: DI
+services.AddForgeMaps();
+// constructor: public MyService(AppMapper mapper)
+
+// Option B: Static instance (simpler, no DI needed)
+private static readonly AppMapper _mapper = new();
+```
+
+## Common Patterns
+
+### Property Renaming
+
+```csharp
+// AutoMapper
+CreateMap<Order, OrderDto>()
+    .ForMember(d => d.OrderDate, o => o.MapFrom(s => s.PlacedAt));
+
+// ForgeMap
+[ForgeProperty(nameof(Order.PlacedAt), nameof(OrderDto.OrderDate))]
+public partial OrderDto Forge(Order source);
+```
+
+### Ignoring Properties
+
+```csharp
+// AutoMapper
+CreateMap<User, UserDto>()
+    .ForMember(d => d.PasswordHash, o => o.Ignore());
+
+// ForgeMap
+[Ignore(nameof(UserDto.PasswordHash))]
+public partial UserDto Forge(User source);
+```
+
+### Custom Value Resolution
+
+```csharp
+// AutoMapper
+CreateMap<User, UserDto>()
+    .ForMember(d => d.FullName, o => o.MapFrom(s => $"{s.First} {s.Last}"));
+
+// ForgeMap
+[ForgeFrom(nameof(UserDto.FullName), nameof(ResolveFullName))]
+public partial UserDto Forge(User source);
+
+private static string ResolveFullName(User source) => $"{source.First} {source.Last}";
+```
+
+### Reverse Mapping
+
+```csharp
+// AutoMapper
+CreateMap<Order, OrderDto>().ReverseMap();
+
+// ForgeMap
+[ReverseForge]
+public partial OrderDto Forge(Order source);
+// Generates both Forge(Order) → OrderDto and Forge(OrderDto) → Order
+```
+
+### Nested Objects
+
+ForgeMap auto-wires nested mappings when a matching `Forge` method exists in the same class:
+
+```csharp
+[ForgeMap]
+public partial class AppMapper
+{
+    public partial OrderDto Forge(Order source);      // auto-wires Address and LineItem
+    public partial AddressDto Forge(Address source);
+    public partial LineItemDto Forge(LineItem source);
+}
+```
+
+### Map Into Existing Object
+
+```csharp
+// AutoMapper
+mapper.Map(source, existingDest);
+
+// ForgeMap
+public partial void ForgeInto(UserDto source, [UseExistingValue] User destination);
+```
+
+### Enum Mapping
+
+ForgeMap handles enum-to-enum, enum-to-string, and string-to-enum automatically:
+
+```csharp
+// Just declare the method — no configuration needed
+public partial StatusDto Forge(StatusEntity source);  // enum → enum by name
+```
+
+### Per-Property Value Conversion
+
+```csharp
+// AutoMapper
+CreateMap<Product, ProductDto>()
+    .ForMember(d => d.PriceText, o => o.MapFrom(s => $"${s.Price:F2}"));
+
+// ForgeMap
+[ForgeProperty(nameof(Product.Price), nameof(ProductDto.PriceText), ConvertWith = nameof(FormatPrice))]
+public partial ProductDto Forge(Product source);
+
+private static string FormatPrice(decimal price) => $"${price:F2}";
+```
+
+### Before/After Hooks
+
+```csharp
+// AutoMapper
+CreateMap<Order, OrderDto>()
+    .AfterMap((s, d) => d.Total = d.Items.Sum(i => i.Price));
+
+// ForgeMap
+[AfterForge(nameof(CalculateTotal))]
+public partial OrderDto Forge(Order source);
+
+private static void CalculateTotal(Order source, OrderDto dest)
+    => dest.Total = dest.Items.Sum(i => i.Price);
+```
+
+### Type Converter (Full Delegation)
+
+```csharp
+// AutoMapper
+CreateMap<Event, StorageModel>().ConvertUsing<EventConverter>();
+
+// ForgeMap
+[ConvertWith(typeof(EventConverter))]
+public partial StorageModel Forge(Event source);
+// EventConverter must implement ITypeConverter<Event, StorageModel>
+```
+
+### Polymorphic / Inheritance Mapping
+
+```csharp
+// AutoMapper
+CreateMap<BaseEntity, BaseDto>().IncludeAllDerived();
+CreateMap<ChildEntity, ChildDto>().IncludeBase<BaseEntity, BaseDto>();
+
+// ForgeMap
+[ForgeAllDerived]
+[Ignore(nameof(BaseDto.AuditTrail))]
+public partial BaseDto Forge(BaseEntity source);
+
+[IncludeBaseForge(typeof(BaseEntity), typeof(BaseDto))]
+public partial ChildDto Forge(ChildEntity source);
+```
+
+## DI Registration
+
+```csharp
+// AutoMapper
+services.AddAutoMapper(typeof(Program).Assembly);
+
+// ForgeMap
+services.AddForgeMaps();
+```
+
+## What ForgeMap Doesn't Support
+
+| AutoMapper Feature | Alternative |
+|---|---|
+| `ProjectTo<T>()` (IQueryable) | Materialize the query first, then map in-memory |
+| `ConstructUsing()` | Use `[ConvertWith]` or `[ForgeFrom]` |
+| `.Condition()` per member | Use `[AfterForge]` hook or `[ForgeFrom]` with conditional logic |
+| Dynamic/runtime mapping | ForgeMap is compile-time only |
+| `ForAllMaps()` global conventions | Apply attributes per mapper — no global convention system |
+
+## Null Handling
+
+AutoMapper assigns null through by default. ForgeMap provides 5 strategies:
+
+| Strategy | Behavior |
+|---|---|
+| `NullForgiving` (default) | Same as AutoMapper — assigns null through |
+| `SkipNull` | Keeps destination's current value when source is null |
+| `CoalesceToDefault` | Null → `""` for strings, `new List<T>()` for collections |
+| `CoalesceToNew` | Null → `new T()` for any type with parameterless constructor |
+| `ThrowException` | Throws `ArgumentNullException` |
+
+Configure at assembly, per-mapper, or per-property level:
+
+```csharp
+[assembly: ForgeMapDefaults(NullPropertyHandling = NullPropertyHandling.CoalesceToDefault)]
+
+[ForgeMap(NullPropertyHandling = NullPropertyHandling.SkipNull)]
+public partial class StrictMapper { ... }
+
+[ForgeProperty("Tags", "Tags", NullPropertyHandling = NullPropertyHandling.ThrowException)]
+public partial OrderDto Forge(Order source);
+```

--- a/docs/migrating-from-automapper.md
+++ b/docs/migrating-from-automapper.md
@@ -50,10 +50,11 @@ The generator auto-discovers that `Forge(Address)` should be used for the `Addre
 
 \* `ForgeInto` is a naming convention, not a built-in method. You must declare it as a `partial void` method with a `[UseExistingValue]` parameter — see [Map Into Existing Object](#map-into-existing-object) below.
 
-**Injection changes:** AutoMapper injects `IMapper`. ForgeMap mappers are plain classes — you can either inject them via DI (`services.AddForgeMaps()`) or use static instances:
+**Injection changes:** AutoMapper injects `IMapper`. ForgeMap mappers are plain classes — you can either inject them via DI or use static instances:
 
 ```csharp
-// Option A: DI
+// Option A: DI (requires Microsoft.Extensions.DependencyInjection)
+// AddForgeMaps() is auto-generated when DI abstractions are referenced.
 services.AddForgeMaps();
 // constructor: public MyService(AppMapper mapper)
 
@@ -225,7 +226,7 @@ services.AddForgeMaps();
 
 ## Null Property Handling
 
-AutoMapper assigns null through by default. ForgeMap provides 5 `NullPropertyHandling` strategies that control how nullable-to-non-nullable **reference type** property assignments are generated. (For null *source objects*, ForgeMap returns `null`/`default` by default — configurable via `NullHandling.ThrowException`.)
+AutoMapper assigns null through by default. ForgeMap provides 5 `NullPropertyHandling` strategies that control how nullable-to-non-nullable property assignments are generated — both nullable reference types (`string?` → `string`) and nullable value types (`int?` → `int`). (For null *source objects*, ForgeMap returns `null`/`default` by default — configurable via `NullHandling.ThrowException`.)
 
 | Strategy | Behavior |
 |---|---|

--- a/docs/migrating-from-automapper.md
+++ b/docs/migrating-from-automapper.md
@@ -131,11 +131,12 @@ public partial class AppMapper
 ### Map Into Existing Object
 
 ```csharp
-// AutoMapper
-mapper.Map(source, existingDest);
+// AutoMapper — map DTO into existing entity (e.g., for EF Core updates)
+mapper.Map(updateDto, existingEntity);
 
-// ForgeMap
+// ForgeMap — declare a void partial method with [UseExistingValue]
 public partial void ForgeInto(UserDto source, [UseExistingValue] User destination);
+// Usage: mapper.ForgeInto(updateDto, existingEntity);
 ```
 
 ### Enum Mapping
@@ -219,14 +220,14 @@ services.AddForgeMaps();
 | AutoMapper Feature | Alternative |
 |---|---|
 | `ProjectTo<T>()` (IQueryable) | Materialize the query first, then map in-memory |
-| `ConstructUsing()` | Use `[ConvertWith]` or `[ForgeFrom]` |
+| `ConstructUsing()` | No direct equivalent. ForgeMap uses constructors/records automatically. For custom factory logic, use `[ConvertWith]` to delegate the entire conversion |
 | `.Condition()` per member | Use `[AfterForge]` hook or `[ForgeFrom]` with conditional logic |
 | Dynamic/runtime mapping | ForgeMap is compile-time only |
 | `ForAllMaps()` global conventions | Apply attributes per mapper — no global convention system |
 
 ## Null Property Handling
 
-AutoMapper assigns null through by default. ForgeMap provides 5 `NullPropertyHandling` strategies that control how nullable-to-non-nullable property assignments are generated — both nullable reference types (`string?` → `string`) and nullable value types (`int?` → `int`). (For null *source objects*, ForgeMap returns `null`/`default` by default — configurable via `NullHandling.ThrowException`.)
+AutoMapper assigns null through by default. ForgeMap provides 5 `NullPropertyHandling` strategies that control how nullable-to-non-nullable property assignments are generated. (For null *source objects*, ForgeMap returns `null`/`default` by default — configurable via `NullHandling.ThrowException`.)
 
 | Strategy | Behavior |
 |---|---|

--- a/docs/migrating-from-automapper.md
+++ b/docs/migrating-from-automapper.md
@@ -45,8 +45,10 @@ The generator auto-discovers that `Forge(Address)` should be used for the `Addre
 | AutoMapper | ForgeMap |
 |---|---|
 | `mapper.Map<UserDto>(user)` | `mapper.Forge(user)` |
-| `mapper.Map(source, dest)` | `mapper.ForgeInto(source, dest)` |
+| `mapper.Map(source, dest)` | `mapper.ForgeInto(source, dest)` * |
 | `mapper.Map<List<UserDto>>(users)` | `users.Select(u => mapper.Forge(u)).ToList()` |
+
+\* `ForgeInto` is a naming convention, not a built-in method. You must declare it as a `partial void` method with a `[UseExistingValue]` parameter — see [Map Into Existing Object](#map-into-existing-object) below.
 
 **Injection changes:** AutoMapper injects `IMapper`. ForgeMap mappers are plain classes — you can either inject them via DI (`services.AddForgeMaps()`) or use static instances:
 
@@ -221,15 +223,15 @@ services.AddForgeMaps();
 | Dynamic/runtime mapping | ForgeMap is compile-time only |
 | `ForAllMaps()` global conventions | Apply attributes per mapper — no global convention system |
 
-## Null Handling
+## Null Property Handling
 
-AutoMapper assigns null through by default. ForgeMap provides 5 strategies:
+AutoMapper assigns null through by default. ForgeMap provides 5 `NullPropertyHandling` strategies that control how nullable-to-non-nullable **reference type** property assignments are generated. (For null *source objects*, ForgeMap returns `null`/`default` by default — configurable via `NullHandling.ThrowException`.)
 
 | Strategy | Behavior |
 |---|---|
 | `NullForgiving` (default) | Same as AutoMapper — assigns null through |
-| `SkipNull` | Keeps destination's current value when source is null |
-| `CoalesceToDefault` | Null → `""` for strings, `new List<T>()` for collections |
+| `SkipNull` | Keeps destination's current value when source property is null |
+| `CoalesceToDefault` | Null → type-appropriate default (`""` for strings, `Array.Empty<T>()` for arrays, `new List<T>()`/`new Dictionary<K,V>()` for collections) |
 | `CoalesceToNew` | Null → `new T()` for any type with parameterless constructor |
 | `ThrowException` | Throws `ArgumentNullException` |
 

--- a/docs/migrating-from-automapper.md
+++ b/docs/migrating-from-automapper.md
@@ -53,8 +53,9 @@ The generator auto-discovers that `Forge(Address)` should be used for the `Addre
 **Injection changes:** AutoMapper injects `IMapper`. ForgeMap mappers are plain classes — you can either inject them via DI or use static instances:
 
 ```csharp
-// Option A: DI (requires Microsoft.Extensions.DependencyInjection package)
-// AddForgeMaps() is auto-generated when the full DI package is referenced.
+// Option A: DI
+// AddForgeMaps() is auto-generated when Microsoft.Extensions.DependencyInjection
+// types are available (e.g., in ASP.NET Core projects).
 services.AddForgeMaps();
 // constructor: public MyService(AppMapper mapper)
 

--- a/src/ForgeMap.Abstractions/ForgeMap.Abstractions.csproj
+++ b/src/ForgeMap.Abstractions/ForgeMap.Abstractions.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
 
     <Description>Attributes and interfaces for ForgeMap, a compile-time object transformation library.</Description>
-    <PackageTags>automapper;mapping;sourcegenerator;dto;transformation</PackageTags>
+    <PackageTags>mapper;mapping;object-mapper;source-generator;automapper;dto;compile-time;roslyn</PackageTags>
 
     <!-- Generate XML docs -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/ForgeMap.Generator/ForgeMap.Generator.csproj
+++ b/src/ForgeMap.Generator/ForgeMap.Generator.csproj
@@ -20,7 +20,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <Description>Source generator for ForgeMap that generates type transformation code at compile time.</Description>
-    <PackageTags>automapper;mapping;sourcegenerator;dto;transformation;roslyn</PackageTags>
+    <PackageTags>mapper;mapping;object-mapper;source-generator;automapper;dto;compile-time;roslyn;code-generation</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
 
     <!-- Only the main ForgeMap package is published -->

--- a/src/ForgeMap/ForgeMap.csproj
+++ b/src/ForgeMap/ForgeMap.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
 
-    <Description>ForgeMap is a lightweight, compile-time object transformation library for .NET. Zero-reflection, source-generator-based mapping with compile-time type safety.</Description>
-    <PackageTags>automapper;mapping;sourcegenerator;dto;transformation;object-mapper</PackageTags>
+    <Description>Compile-time object mapper for .NET using Roslyn source generators. Zero runtime reflection, MIT licensed. Supports property mapping, reverse mapping, nested objects, collections, enums, constructor mapping, and custom converters.</Description>
+    <PackageTags>mapper;mapping;object-mapper;source-generator;automapper;automapper-alternative;dto;compile-time;roslyn;code-generation;dotnet;csharp</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
 


### PR DESCRIPTION
## Summary

Add a public-facing migration guide for developers switching from AutoMapper to ForgeMap, and update package metadata for discoverability.

### Documentation changes

- **`docs/migrating-from-automapper.md`** — Step-by-step guide covering:
  - Package swap instructions
  - Profile → `[ForgeMap]` class conversion
  - `IMapper` call site replacement patterns
  - 12 common patterns with before/after code (renaming, ignore, custom resolution, reverse, nested, ForgeInto, enums, ConvertWith, hooks, type converter, polymorphism)
  - DI registration
  - Null property handling strategy comparison (5 strategies vs AutoMapper's default)
  - Unsupported features table with alternatives

- **README.md** — Added "Coming from AutoMapper?" section linking to the migration guide and existing comparison doc

### Package metadata changes (from merged #123)

- **`ForgeMap.csproj`** — Updated NuGet description and tags for discoverability (`automapper-alternative`, `source-generator`, `compile-time`, etc.)
- **`ForgeMap.Generator.csproj`** / **`ForgeMap.Abstractions.csproj`** — Aligned tags